### PR TITLE
std::array in Stack

### DIFF
--- a/blazert/datatypes.h
+++ b/blazert/datatypes.h
@@ -57,7 +57,7 @@ using Mat3rList = std::vector<Mat3r<T>, blaze::AlignedAllocator<Mat3r<T>>>;
 
 template<typename T, unsigned int capacity = 0>
 struct Stack {
-  T stack[capacity];
+  std::array<T, capacity> stack;
   unsigned int ss = 0;
   inline void push_back(T node) { stack[ss++] = node; }
   inline void pop_back() { stack[ss--] = 0; }


### PR DESCRIPTION
## Status
**READY**

## Description
Using std::array in Stack class instead of c-style array. Kind of addressing issue #38.

std::array doesn't solve the problem alone as suggested by #38, because we still need to keep track of where we last added elements within the array in order to provide push_back and pop_back functionality. 

There is also std::stack<T> in C++, however, this allocates memory on the heap which is not what we want. 

The solution now is not really advantageous as far as I can tell, but it C++ifies the codebase some more.

## Type of Change
- [ ] bug fix 
- [ ] new features
- [ ] documentation
- [x] other 

## Checklist
- [x] I have run the provided clang-format
- [x] I have reviewed my code and commented if necessary
- [ ] I have added the appropriate documentation
- [ ] I have added tests to my new code
- [x] All tests pass locally
