### PR TITLE
Clean API for ray construction

### DIFF
--- a/.github/ISSUE_TEMPLATE/enhancement_request.md
+++ b/.github/ISSUE_TEMPLATE/enhancement_request.md
@@ -1,0 +1,17 @@
+---
+name: Enhancement
+about: Suggest an enhancement to improve the code base
+title: "[ENHANCEMENT]"
+labels: ''
+assignees: ''
+
+---
+
+**Describe the enhancement**
+A clear and concise description of the enhancement you propose, e.g. fix warning for specific flags, etc.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Additional context**
+Add any other context about the problem here.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,12 +14,12 @@ ENDIF()
 # Compiler Flags
 set(CMAKE_CXX_STANDARD 17)
 IF (CMAKE_COMPILER_IS_GNUCXX)
-    set(CMAKE_CXX_FLAGS "-std=c++17 -O3 -Wall -fPIC -funroll-loops -march=native ${COVERAGE_FLAGS}")
+    set(CMAKE_CXX_FLAGS "-std=c++17 -O3 -Wall -Wpedantic -Wsign-conversion -fPIC -funroll-loops -march=native ${COVERAGE_FLAGS}")
 ELSEIF (MSVC)
     # this currently works, but is not really the way to go..
     set(CMAKE_CXX_FLAGS "/std:c++17 /Wall /arch:AVX")
 ELSE ()
-    set(CMAKE_CXX_FLAGS "-std=c++17 -O3 -Wall -fPIC -funroll-loops -march=native -fno-finite-math-only -fno-signed-zeros -freciprocal-math -ffp-contract=fast")
+    set(CMAKE_CXX_FLAGS "-std=c++17 -O3 -Wall -Wpedantic -Wsign-conversion -fPIC -funroll-loops -march=native -fno-finite-math-only -fno-signed-zeros -freciprocal-math -ffp-contract=fast")
 ENDIF (CMAKE_COMPILER_IS_GNUCXX)
 
 IF (FORCE_COLOR_OUTPUT)

--- a/benchmarks/benchmark_BVH/benchmark_BVH_build.cpp
+++ b/benchmarks/benchmark_BVH/benchmark_BVH_build.cpp
@@ -118,7 +118,7 @@ static void BM_bvh_BUILD_BHV_Sphere_SweepSAH(benchmark::State &state) {
   const auto os = std::make_unique<OriginSphere<T>>(state.range(0));
 
   std::vector<Triangle> triangles;
-  triangles.reserve(os->triangles.size()/3);
+  triangles.reserve(os->triangles.size() / 3);
   for (uint32_t i = 0; i < os->triangles.size(); i += 3) {
     const Vec3ui &face = os->triangles[i];
     const Vec3r<T> &p0 = os->vertices[face[0]];
@@ -148,7 +148,7 @@ static void BM_bvh_BUILD_BHV_Sphere_BinnedSAH(benchmark::State &state) {
   const auto os = std::make_unique<OriginSphere<T>>(state.range(0));
 
   std::vector<Triangle> triangles;
-  triangles.reserve(os->triangles.size()/3);
+  triangles.reserve(os->triangles.size() / 3);
   for (uint32_t i = 0; i < os->triangles.size(); i += 3) {
     const Vec3ui &face = os->triangles[i];
     const Vec3r<T> &p0 = os->vertices[face[0]];

--- a/blazert/bvh/accel.h
+++ b/blazert/bvh/accel.h
@@ -83,7 +83,7 @@ inline bool traverse(const BVH<T, Collection> &bvh, const Ray<T> &ray, RayHit<T>
       else if (intersect_leaf(node, intersector, ray)) {
         /// If a prim is hit, use this distance as max distance for all subsequent ray box intersections.
         hit_distance = intersector.hit_distance;
-        if (ray.any_hit)
+        if (ray.any_hit == Ray<T>::AnyHit::yes)
           break;
       }
     }

--- a/blazert/bvh/accel.h
+++ b/blazert/bvh/accel.h
@@ -73,7 +73,7 @@ inline bool traverse(const BVH<T, Collection> &bvh, const Ray<T> &ray, RayHit<T>
 
     if (intersect_node(min_hit_distance, max_hit_distance, node, ray)) {
       if (!node.leaf) {// Branch node
-        const int order_near = ray.direction_sign[node.axis];
+        const unsigned int order_near = ray.direction_sign[node.axis];
         node_stack.push_back(node.children[1 - order_near]);
         node_stack.push_back(node.children[order_near]);
       }

--- a/blazert/bvh/binbuffer.h
+++ b/blazert/bvh/binbuffer.h
@@ -81,13 +81,13 @@ inline std::pair<unsigned int, Vec3r<T>> find_best_split_binned(const Collection
   Vec3r<T> cut_pos;
   Vec3r<T> min_cost(std::numeric_limits<T>::max());
 
-  for (int j = 0; j < 3; j++) {
+  for (std::size_t j = 0; j < 3; j++) {
     // Sweep left to accumulate bounding boxes and compute the right-hand side of the cost
     size_t count = 0;
     Vec3r<T> min_(std::numeric_limits<T>::max());
     Vec3r<T> max_(-std::numeric_limits<T>::max());
 
-    for (size_t i = bins.size - 1; i > 0; i--) {
+    for (std::size_t i = bins.size - 1; i > 0; i--) {
       Bin<T> &bin = bins.bin[j * bins.size + i];
       unity(min_, max_, bin.min, bin.max);
       count += bin.count;
@@ -101,7 +101,7 @@ inline std::pair<unsigned int, Vec3r<T>> find_best_split_binned(const Collection
 
     unsigned int min_bin = 1;
 
-    for (size_t i = 0; i < bins.size - 1; i++) {
+    for (std::size_t i = 0; i < bins.size - 1; i++) {
       Bin<T> &bin = bins.bin[j * bins.size + i];
       Bin<T> &next_bin = bins.bin[j * bins.size + i + 1];
       unity(min_, max_, bin.min, bin.max);

--- a/blazert/bvh/builder.h
+++ b/blazert/bvh/builder.h
@@ -94,14 +94,14 @@ inline BVHNode<T, Collection> create_leaf(const Collection<T> &collection, Itera
   node.max = bmax;
 
   node.leaf = 1;
-  node.primitives.reserve(std::distance(begin, end));
+  node.primitives.reserve(static_cast<long unsigned int>(std::distance(begin, end)));
 
   for (auto it = begin; it != end; ++it) {
     node.primitives.push_back(std::move(primitive_from_collection(collection, *it)));
   }
 
   return node;
-};
+}
 
 template<typename T, typename Iterator, template<typename> typename Collection>
 inline std::pair<BVHNode<T, Collection>, Iterator>

--- a/blazert/bvh/intersect.h
+++ b/blazert/bvh/intersect.h
@@ -42,7 +42,7 @@ inline bool intersect_leaf(const Node &node, Intersector &intersector, const Ray
 
   for (auto &primitive : node.primitives) {
     hit += intersect_primitive(intersector, primitive, ray);
-    if (hit && ray.any_hit) {
+    if (hit && (ray.any_hit == Ray::AnyHit::yes)) {
       break;
     }
   }

--- a/blazert/bvh/intersect.h
+++ b/blazert/bvh/intersect.h
@@ -22,7 +22,7 @@ inline bool intersect_node(T &min_distance /* inout */, T &max_distance /* inout
   constexpr T l1 = static_cast<T>(1) + static_cast<T>(4) * std::numeric_limits<T>::epsilon();
   T min_, max_;
 
-  for (int i = 0; i < 3; i++) {
+  for (std::size_t i = 0; i < 3; i++) {
     min_ = ray.direction_sign[i] ? node.max[i] : node.min[i];
     max_ = ray.direction_sign[i] ? node.min[i] : node.max[i];
 

--- a/blazert/embree/primitives/EmbreeGeometryObject.h
+++ b/blazert/embree/primitives/EmbreeGeometryObject.h
@@ -19,7 +19,7 @@ public:
   EmbreeGeometryObject(const RTCScene &scene) : scene(scene){};
 
   RTCGeometry geometry;
-  unsigned int geomID = -1;
+  unsigned int geomID = static_cast<unsigned int>(-1);
   unsigned int kind = 0;
 };
 

--- a/blazert/embree/scene.h
+++ b/blazert/embree/scene.h
@@ -160,7 +160,7 @@ inline bool intersect1(const EmbreeScene<T> &scene, const Ray<T> &ray, RayHit<T>
 template<typename T>
 unsigned int EmbreeScene<T>::add_mesh(const Vec3rList<T> &vertices, const Vec3iList &triangles) {
 
-  unsigned int id = -1;
+  unsigned int id = static_cast<unsigned int>(-1);
 
   if constexpr (std::is_same<float, T>::value) {
     constexpr const int bytestride_int = sizeof(Vec3ui) / 8 * sizeof(Vec3ui::ElementType);
@@ -201,7 +201,7 @@ unsigned int EmbreeScene<T>::add_mesh(const Vec3rList<T> &vertices, const Vec3iL
 template<typename T>
 unsigned int EmbreeScene<T>::add_spheres(const Vec3rList<T> &centers, const std::vector<T> &radii) {
 
-  unsigned int id = -1;
+  unsigned int id = static_cast<unsigned int>(-1);
 
   if constexpr (std::is_same<float, T>::value) {
     // TODO: We are looking for something more like this:
@@ -246,7 +246,7 @@ template<typename T>
 unsigned int EmbreeScene<T>::add_planes(const Vec3rList<T> &centers, const std::vector<T> &dxs,
                                         const std::vector<T> &dys, const Mat3rList<T> &rotations) {
 
-  unsigned int id = -1;
+  unsigned int id = static_cast<unsigned int>(-1);
 
   if constexpr (std::is_same<float, T>::value) {
     plane = std::make_unique<EmbreePlane>(device, rtcscene, centers[0], dxs[0], dys[0], rotations[0]);
@@ -294,7 +294,7 @@ template<typename T>
 unsigned int EmbreeScene<T>::add_cylinders(const Vec3rList<T> &centers, const std::vector<T> &semi_axes_a,
                                            const std::vector<T> &semi_axes_b, const std::vector<T> &heights,
                                            const Mat3rList<T> &rotations) {
-  unsigned int id = -1;
+  unsigned int id = static_cast<unsigned int>(-1);
 
   if constexpr (std::is_same<float, T>::value) {
     cylinder = std::make_unique<EmbreeCylinder>(device, rtcscene, centers[0], semi_axes_a[0], semi_axes_b[0],

--- a/blazert/embree/scene.h
+++ b/blazert/embree/scene.h
@@ -142,7 +142,6 @@ inline bool intersect1(const EmbreeScene<T> &scene, const Ray<T> &ray, RayHit<T>
   return hit;
 }
 
-
 /**
  * @brief Adds a triangular mesh to the scene
  * @details

--- a/blazert/primitives/cylinder.h
+++ b/blazert/primitives/cylinder.h
@@ -66,7 +66,8 @@ public:
   unsigned int prim_id;
 
   CylinderIntersector() = delete;
-  explicit CylinderIntersector(const Collection<T> &collection) : collection(collection), prim_id(static_cast<unsigned int>(-1)) {}
+  explicit CylinderIntersector(const Collection<T> &collection)
+      : collection(collection), prim_id(static_cast<unsigned int>(-1)) {}
 };
 
 template<typename T>

--- a/blazert/primitives/cylinder.h
+++ b/blazert/primitives/cylinder.h
@@ -49,7 +49,7 @@ inline Cylinder<T> primitive_from_collection(const Collection<T> &collection, co
   const T &height = collection.heights[prim_idx];
   const Mat3r<T> &rotation = collection.rotations[prim_idx];
   return {center, semi_axis_a, semi_axis_b, height, rotation, prim_idx};
-};
+}
 
 template<typename T, template<typename A> typename Collection>
 class CylinderIntersector {
@@ -66,7 +66,7 @@ public:
   unsigned int prim_id;
 
   CylinderIntersector() = delete;
-  explicit CylinderIntersector(const Collection<T> &collection) : collection(collection), prim_id(-1) {}
+  explicit CylinderIntersector(const Collection<T> &collection) : collection(collection), prim_id(static_cast<unsigned int>(-1)) {}
 };
 
 template<typename T>
@@ -168,7 +168,7 @@ inline void prepare_traversal(CylinderIntersector<T, Collection> &i, const Ray<T
   i.min_hit_distance = ray.min_hit_distance;
   i.hit_distance = ray.max_hit_distance;
   i.uv = static_cast<T>(0.);
-  i.prim_id = -1;
+  i.prim_id = static_cast<unsigned int>(-1);
 }
 
 /**

--- a/blazert/primitives/plane.h
+++ b/blazert/primitives/plane.h
@@ -64,7 +64,8 @@ public:
   unsigned int prim_id;
 
   PlaneIntersector() = delete;
-  explicit PlaneIntersector(const Collection<T> &collection) : collection(collection), prim_id(static_cast<unsigned int>(-1)) {}
+  explicit PlaneIntersector(const Collection<T> &collection)
+      : collection(collection), prim_id(static_cast<unsigned int>(-1)) {}
 };
 
 template<typename T>

--- a/blazert/primitives/plane.h
+++ b/blazert/primitives/plane.h
@@ -47,7 +47,7 @@ inline Plane<T> primitive_from_collection(const Collection<T> &collection, const
   const T &dy = collection.dys[prim_idx];
   const Mat3r<T> &rotation = collection.rotations[prim_idx];
   return {center, dx, dy, rotation, prim_idx};
-};
+}
 
 template<typename T, template<typename A> typename Collection>
 class PlaneIntersector {
@@ -64,7 +64,7 @@ public:
   unsigned int prim_id;
 
   PlaneIntersector() = delete;
-  explicit PlaneIntersector(const Collection<T> &collection) : collection(collection), prim_id(-1) {}
+  explicit PlaneIntersector(const Collection<T> &collection) : collection(collection), prim_id(static_cast<unsigned int>(-1)) {}
 };
 
 template<typename T>
@@ -168,7 +168,7 @@ inline void prepare_traversal(PlaneIntersector<T, Collection> &i, const Ray<T> &
   i.min_hit_distance = ray.min_hit_distance;
   i.hit_distance = ray.max_hit_distance;
   i.uv = static_cast<T>(0.);
-  i.prim_id = -1;
+  i.prim_id = static_cast<unsigned int>(-1);
 }
 
 /**

--- a/blazert/primitives/sphere.h
+++ b/blazert/primitives/sphere.h
@@ -53,7 +53,8 @@ public:
   unsigned int prim_id;
 
   SphereIntersector() = delete;
-  explicit SphereIntersector(const Collection<T> &collection) : collection(collection), prim_id(static_cast<unsigned int>(-1)) {}
+  explicit SphereIntersector(const Collection<T> &collection)
+      : collection(collection), prim_id(static_cast<unsigned int>(-1)) {}
 };
 
 template<typename T>

--- a/blazert/primitives/sphere.h
+++ b/blazert/primitives/sphere.h
@@ -37,7 +37,7 @@ inline Sphere<T> primitive_from_collection(const Collection<T> &collection, cons
   const Vec3r<T> &center = collection.centers[prim_idx];
   const T &radius = collection.radii[prim_idx];
   return {center, radius, prim_idx};
-};
+}
 
 template<typename T, template<typename A> typename Collection>
 class SphereIntersector {
@@ -53,7 +53,7 @@ public:
   unsigned int prim_id;
 
   SphereIntersector() = delete;
-  explicit SphereIntersector(const Collection<T> &collection) : collection(collection), prim_id(-1) {}
+  explicit SphereIntersector(const Collection<T> &collection) : collection(collection), prim_id(static_cast<unsigned int>(-1)) {}
 };
 
 template<typename T>
@@ -128,7 +128,7 @@ inline void prepare_traversal(SphereIntersector<T, Collection> &i, const Ray<T> 
   i.min_hit_distance = ray.min_hit_distance;
   i.hit_distance = ray.max_hit_distance;
   i.uv = static_cast<T>(0.);
-  i.prim_id = -1;
+  i.prim_id = static_cast<unsigned int>(-1);
 }
 
 /**

--- a/blazert/primitives/trimesh.h
+++ b/blazert/primitives/trimesh.h
@@ -39,7 +39,7 @@ inline Triangle<T> primitive_from_collection(const Collection<T> &collection, co
   const Vec3r<T> &b = collection.vertices[face[1]];
   const Vec3r<T> &c = collection.vertices[face[2]];
   return {a, b, c, prim_idx};
-};
+}
 
 template<typename T, template<typename A> typename Collection>
 class TriangleIntersector {
@@ -53,7 +53,7 @@ public:
   unsigned int prim_id;
 
   TriangleIntersector() = delete;
-  explicit TriangleIntersector(const Collection<T> &collection) : collection(collection), prim_id(-1) {}
+  explicit TriangleIntersector(const Collection<T> &collection) : collection(collection), prim_id(static_cast<unsigned int>(-1)) {}
 };
 
 template<typename T>
@@ -145,7 +145,7 @@ inline void prepare_traversal(TriangleIntersector<T, Collection> &i, const Ray<T
   i.min_hit_distance = ray.min_hit_distance;
   i.hit_distance = ray.max_hit_distance;
   i.uv = static_cast<T>(0.);
-  i.prim_id = -1;
+  i.prim_id = static_cast<unsigned int>(-1);
 }
 
 template<typename T, template<typename> typename Collection>

--- a/blazert/primitives/trimesh.h
+++ b/blazert/primitives/trimesh.h
@@ -53,7 +53,8 @@ public:
   unsigned int prim_id;
 
   TriangleIntersector() = delete;
-  explicit TriangleIntersector(const Collection<T> &collection) : collection(collection), prim_id(static_cast<unsigned int>(-1)) {}
+  explicit TriangleIntersector(const Collection<T> &collection)
+      : collection(collection), prim_id(static_cast<unsigned int>(-1)) {}
 };
 
 template<typename T>

--- a/blazert/primitives/trimesh_distance.h
+++ b/blazert/primitives/trimesh_distance.h
@@ -38,7 +38,7 @@ inline void r0(T &s, T &t, const T &det) {
   const T inv_det = T(1.) / det;
   s *= inv_det;
   t *= inv_det;
-};
+}
 
 template<typename T>
 inline void r1(T &s, T &t, const T &a, const T &b, const T &c, const T &d, const T &e) {
@@ -54,7 +54,7 @@ inline void r1(T &s, T &t, const T &a, const T &b, const T &c, const T &d, const
     }
   }
   t = T(1.) - s;
-};
+}
 
 template<typename T>
 inline void r2(T &s, T &t, const T &a, const T &b, const T &c, const T &d, const T &e) {
@@ -80,7 +80,7 @@ inline void r2(T &s, T &t, const T &a, const T &b, const T &c, const T &d, const
         t = -e / c;
     }
   }
-};
+}
 
 template<typename T>
 inline void r3(T &s, T &t, const T &c, const T &e) {
@@ -96,7 +96,7 @@ inline void r3(T &s, T &t, const T &c, const T &e) {
       t = -e / c;
     }
   }
-};
+}
 
 template<typename T>
 inline void r4(T &s, T &t, const T &a, const T &c, const T &d, const T &e) {
@@ -119,7 +119,7 @@ inline void r4(T &s, T &t, const T &a, const T &c, const T &d, const T &e) {
         t = -e / c;
     }
   }
-};
+}
 
 template<typename T>
 inline void r5(T &s, T &t, const T &a, const T &d, const T &f) {
@@ -135,7 +135,7 @@ inline void r5(T &s, T &t, const T &a, const T &d, const T &f) {
       s = -d / a;
     }
   }
-};
+}
 
 template<typename T>
 inline void r6(T &s, T &t, const T &a, const T &b, const T &c, const T &d, const T &e) {
@@ -161,7 +161,7 @@ inline void r6(T &s, T &t, const T &a, const T &b, const T &c, const T &d, const
         s = -d / a;
     }
   }
-};
+}
 
 /**
  * @brief Compute the closest point on a triangle for a given test point. This only works for well-formed triangles.
@@ -214,7 +214,7 @@ inline Vec3r<T> closest_point_on_triangle(const Vec3r<T> &tri_v0, const Vec3r<T>
   }
 
   return tri_v0 + s * E0 + t * E1;
-};
+}
 
 }// namespace blazert
 

--- a/blazert/ray.h
+++ b/blazert/ray.h
@@ -46,6 +46,7 @@ public:
    * @param any_hit If true, the first hit found in the traversal will register as the hit, which might not be the hit (default = false) closest to the ray origin.
    *
    * @todo backface culling is no implemented yet.
+   * @todo replace boolean variables by enum classes for choices
    *
    *
    */
@@ -74,9 +75,9 @@ struct BLAZERTALIGN RayHit {
   /// distance between ray origin and the intersection point
   T hit_distance = std::numeric_limits<T>::max();
   /// primitive id of the hit object (= which exact primitive was it)
-  unsigned int prim_id = -1;
+  unsigned int prim_id = static_cast<unsigned int>(-1);
   /// geometry id of the hit object (= which kind of geometry was it, e.g. sphere, triangle)
-  unsigned int geom_id = -1;
+  unsigned int geom_id = static_cast<unsigned int>(-1);
 };
 
 }// namespace blazert

--- a/blazert/ray.h
+++ b/blazert/ray.h
@@ -33,8 +33,6 @@ public:
   CullBackFace cull_back_face;
   AnyHit any_hit;
 
-
-
 public:
   Ray() = delete;
   /**
@@ -48,8 +46,8 @@ public:
    * @param direction Dircetion in which the ray is launched.
    * @param min_hit_distance  Minimum length the ray needs to have (default = 0).
    * @param max_hit_distance Maximum length the ray can have (default = std::numeric_limits<T>::max()).
-   * @param cull_back_face If true, culling backfaces will be used (default = false).
-   * @param any_hit If true, the first hit found in the traversal will register as the hit, which might not be the hit (default = false) closest to the ray origin.
+   * @param cull_back_face If set to blazert::Ray<T>::CullBackFace::yes, culling backfaces will be used (default = no).
+   * @param any_hit If set to blazert::Ray<T>::AnyHit::yes, the first hit found in the traversal will register as the hit, which might not be the hit (default = no) closest to the ray origin.
    *
    * @todo backface culling is no implemented yet.
    * @todo replace boolean variables by enum classes for choices
@@ -57,7 +55,8 @@ public:
    *
    */
   Ray(const Vec3r<T> &origin, const Vec3r<T> &direction, T min_hit_distance = T(0.),
-      T max_hit_distance = std::numeric_limits<T>::max(), CullBackFace cull_back_face = CullBackFace::no, AnyHit any_hit = AnyHit::no)
+      T max_hit_distance = std::numeric_limits<T>::max(), CullBackFace cull_back_face = CullBackFace::no,
+      AnyHit any_hit = AnyHit::no)
       : origin{origin}, direction{normalize(direction)},
         direction_inv{(static_cast<T>(1.) / direction)},// TODO: maybe normalize on creation?
         direction_sign{static_cast<unsigned int>(direction[0] < static_cast<T>(0.0) ? 1 : 0),

--- a/blazert/ray.h
+++ b/blazert/ray.h
@@ -20,14 +20,20 @@ namespace blazert {
 template<typename T>
 class BLAZERTALIGN Ray {
 public:
+  enum class CullBackFace { yes, no };
+  enum class AnyHit { yes, no };
+
+public:
   const Vec3r<T> origin;
   const Vec3r<T> direction;
   const Vec3r<T> direction_inv;
   const Vec3ui direction_sign;
   T min_hit_distance;
   T max_hit_distance;
-  bool cull_back_face;
-  bool any_hit;
+  CullBackFace cull_back_face;
+  AnyHit any_hit;
+
+
 
 public:
   Ray() = delete;
@@ -51,7 +57,7 @@ public:
    *
    */
   Ray(const Vec3r<T> &origin, const Vec3r<T> &direction, T min_hit_distance = T(0.),
-      T max_hit_distance = std::numeric_limits<T>::max(), bool cull_back_face = false, bool any_hit = false)
+      T max_hit_distance = std::numeric_limits<T>::max(), CullBackFace cull_back_face = CullBackFace::no, AnyHit any_hit = AnyHit::no)
       : origin{origin}, direction{normalize(direction)},
         direction_inv{(static_cast<T>(1.) / direction)},// TODO: maybe normalize on creation?
         direction_sign{static_cast<unsigned int>(direction[0] < static_cast<T>(0.0) ? 1 : 0),

--- a/blazert/scene.h
+++ b/blazert/scene.h
@@ -51,22 +51,22 @@ public:
 
   std::unique_ptr<TriangleMesh<T>> triangle_collection;
   std::unique_ptr<BVH<T, TriangleMesh>> triangles_bvh;
-  size_t triangles_geom_id = -1;
+  size_t triangles_geom_id = static_cast<unsigned int>(-1);
   bool has_triangles = false;
 
   std::unique_ptr<SphereCollection<T>> sphere_collection;
   std::unique_ptr<BVH<T, SphereCollection>> spheres_bvh;
-  size_t spheres_geom_id = -1;
+  size_t spheres_geom_id = static_cast<unsigned int>(-1);
   bool has_spheres = false;
 
   std::unique_ptr<PlaneCollection<T>> plane_collection;
   std::unique_ptr<BVH<T, PlaneCollection>> planes_bvh;
-  size_t planes_geom_id = -1;
+  size_t planes_geom_id = static_cast<unsigned int>(-1);
   bool has_planes = false;
 
   std::unique_ptr<CylinderCollection<T>> cylinder_collection;// these are needed for lifetime management...
   std::unique_ptr<BVH<T, CylinderCollection>> cylinders_bvh;
-  size_t cylinders_geom_id = -1;
+  size_t cylinders_geom_id = static_cast<unsigned int>(-1);
   bool has_cylinders = false;
 
 public:
@@ -274,7 +274,7 @@ unsigned int BlazertScene<T>::add_planes(const Vec3rList<T> &centers, const std:
     planes_geom_id = geometries++;
     return planes_geom_id;
   } else {
-    return -1;
+    return static_cast<unsigned int>(-1);
   }
 }
 
@@ -313,7 +313,7 @@ unsigned int BlazertScene<T>::add_cylinders(const Vec3rList<T> &centers, const s
     cylinders_geom_id = geometries++;
     return cylinders_geom_id;
   } else {
-    return -1;
+    return static_cast<unsigned int>(-1);
   }
 }
 

--- a/blazert/scene.h
+++ b/blazert/scene.h
@@ -209,7 +209,6 @@ unsigned int BlazertScene<T>::add_mesh(const Vec3rList<T> &vertices, const Vec3i
   }
 }
 
-
 /**
  * @brief Adds spheres at centers with radii.
  *
@@ -240,7 +239,6 @@ unsigned int BlazertScene<T>::add_spheres(const Vec3rList<T> &centers, const std
     return static_cast<unsigned int>(-1);
   }
 }
-
 
 /**
  * @brief Adds planes at centers with dimensions dxs and dys rotated around rotations.

--- a/examples/path_tracer/main.cc
+++ b/examples/path_tracer/main.cc
@@ -263,7 +263,7 @@ inline bool check_for_occluder(const Vec3r<T> &p1, const Vec3r<T> &p2, const Mes
   Vec3r<T> dir{p2 - p1};
   const T dist = length(dir);
 
-  const blazert::Ray<T> shadow_ray{p1, dir, ray_eps, dist - ray_eps, false, true};
+  const blazert::Ray<T> shadow_ray{p1, dir, ray_eps, dist - ray_eps, blazert::Ray<T>::CullBackFace::no, blazert::Ray<T>::AnyHit::yes};
 
   blazert::RayHit<T> rayhit;
   return traverse(bvh, shadow_ray, rayhit);

--- a/test/test_helpers.h
+++ b/test/test_helpers.h
@@ -53,7 +53,7 @@ inline void cube_mesh_ccw(const Vec3r<T> &center, Vec3rList<T> &vertices, Vec3iL
   indices.emplace_back(Vec3ui{4, 5, 7});
   indices.emplace_back(Vec3ui{3, 2, 1});
   indices.emplace_back(Vec3ui{0, 3, 1});
-};
+}
 
 // CW = clockwise
 template<typename T>
@@ -81,7 +81,7 @@ inline void cube_mesh_cw(const Vec3r<T> &center, Vec3rList<T> &vertices, Vec3iLi
   indices.emplace_back(Vec3ui{4, 7, 5});
   indices.emplace_back(Vec3ui{3, 1, 2});
   indices.emplace_back(Vec3ui{0, 1, 3});
-};
+}
 
 template<typename T>
 inline void single_triangle_ccw(const Vec3r<T> &center, Vec3rList<T> &vertices, Vec3iList &indices) {
@@ -91,7 +91,7 @@ inline void single_triangle_ccw(const Vec3r<T> &center, Vec3rList<T> &vertices, 
   vertices.emplace_back(Vec3r<T>{center[0] + T(1.), center[1] + T(1.), center[2] + T(-1.)});
 
   indices.emplace_back(Vec3ui{0, 2, 1});
-};
+}
 
 template<typename T>
 inline void single_triangle_cw(const Vec3r<T> &center, Vec3rList<T> &vertices, Vec3iList &indices) {
@@ -101,7 +101,7 @@ inline void single_triangle_cw(const Vec3r<T> &center, Vec3rList<T> &vertices, V
   vertices.emplace_back(Vec3r<T>{center[0] + T(1.), center[1] + T(1.), center[2] + T(-1.)});
 
   indices.emplace_back(Vec3ui{0, 1, 2});
-};
+}
 
 template<typename T1, typename T2>
 bool Mat3_isApprox(Mat3r<T1> &m1, Mat3r<T2> &m2) {

--- a/test/test_primitives/test_cylinder.cpp
+++ b/test/test_primitives/test_cylinder.cpp
@@ -574,7 +574,7 @@ TEST_CASE_TEMPLATE("cylinder", T, float, double) {
               CylinderCollection<T> cylinders{*centers, *semi_axes_a, *semi_axes_b, *heights, *rotations};
 
               const bool true_hit = false;
-              const unsigned int true_prim_id = -1;
+              const unsigned int true_prim_id = static_cast<unsigned int>(-1);
               const T true_distance = std::numeric_limits<T>::max();
               const Vec3r<T> true_normal{0, 0, 0};
               SUBCASE("intersect primitive") {
@@ -592,7 +592,7 @@ TEST_CASE_TEMPLATE("cylinder", T, float, double) {
               CylinderCollection<T> cylinders{*centers, *semi_axes_a, *semi_axes_b, *heights, *rotations};
 
               const bool true_hit = false;
-              const unsigned int true_prim_id = -1;
+              const unsigned int true_prim_id = static_cast<unsigned int>(-1);
               const T true_distance = std::numeric_limits<T>::max();
               const Vec3r<T> true_normal{0, 0, 0};
               SUBCASE("intersect primitive") {
@@ -609,7 +609,7 @@ TEST_CASE_TEMPLATE("cylinder", T, float, double) {
               CylinderCollection<T> cylinders{*centers, *semi_axes_a, *semi_axes_b, *heights, *rotations};
 
               const bool true_hit = false;
-              const unsigned int true_prim_id = -1;
+              const unsigned int true_prim_id = static_cast<unsigned int>(-1);
               const T true_distance = std::numeric_limits<T>::max();
               const Vec3r<T> true_normal{0, 0, 0};
               SUBCASE("intersect primitive") {
@@ -626,7 +626,7 @@ TEST_CASE_TEMPLATE("cylinder", T, float, double) {
               CylinderCollection<T> cylinders{*centers, *semi_axes_a, *semi_axes_b, *heights, *rotations};
 
               const bool true_hit = false;
-              const unsigned int true_prim_id = -1;
+              const unsigned int true_prim_id = static_cast<unsigned int>(-1);
               const T true_distance = std::numeric_limits<T>::max();
               const Vec3r<T> true_normal{0, 0, 0};
               SUBCASE("intersect primitive") {
@@ -643,7 +643,7 @@ TEST_CASE_TEMPLATE("cylinder", T, float, double) {
               CylinderCollection<T> cylinders{*centers, *semi_axes_a, *semi_axes_b, *heights, *rotations};
 
               const bool true_hit = false;
-              const unsigned int true_prim_id = -1;
+              const unsigned int true_prim_id = static_cast<unsigned int>(-1);
               const T true_distance = std::numeric_limits<T>::max();
               const Vec3r<T> true_normal{0, 0, 0};
               SUBCASE("intersect primitive") {
@@ -660,7 +660,7 @@ TEST_CASE_TEMPLATE("cylinder", T, float, double) {
               CylinderCollection<T> cylinders{*centers, *semi_axes_a, *semi_axes_b, *heights, *rotations};
 
               const bool true_hit = false;
-              const unsigned int true_prim_id = -1;
+              const unsigned int true_prim_id = static_cast<unsigned int>(-1);
               const T true_distance = std::numeric_limits<T>::max();
               const Vec3r<T> true_normal{0, 0, 0};
               SUBCASE("intersect primitive") {
@@ -680,7 +680,7 @@ TEST_CASE_TEMPLATE("cylinder", T, float, double) {
               CylinderCollection<T> cylinders{*centers, *semi_axes_a, *semi_axes_b, *heights, *rotations};
 
               const bool true_hit = false;
-              const unsigned int true_prim_id = -1;
+              const unsigned int true_prim_id = static_cast<unsigned int>(-1);
               const T true_distance = std::numeric_limits<T>::max();
               const Vec3r<T> true_normal{0, 0, 0};
               SUBCASE("intersect primitive") {
@@ -698,7 +698,7 @@ TEST_CASE_TEMPLATE("cylinder", T, float, double) {
               CylinderCollection<T> cylinders{*centers, *semi_axes_a, *semi_axes_b, *heights, *rotations};
 
               const bool true_hit = false;
-              const unsigned int true_prim_id = -1;
+              const unsigned int true_prim_id = static_cast<unsigned int>(-1);
               const T true_distance = std::numeric_limits<T>::max();
               const Vec3r<T> true_normal{0, 0, 0};
               SUBCASE("intersect primitive") {
@@ -715,7 +715,7 @@ TEST_CASE_TEMPLATE("cylinder", T, float, double) {
               CylinderCollection<T> cylinders{*centers, *semi_axes_a, *semi_axes_b, *heights, *rotations};
 
               const bool true_hit = false;
-              const unsigned int true_prim_id = -1;
+              const unsigned int true_prim_id = static_cast<unsigned int>(-1);
               const T true_distance = std::numeric_limits<T>::max();
               const Vec3r<T> true_normal{0, 0, 0};
               SUBCASE("intersect primitive") {
@@ -732,7 +732,7 @@ TEST_CASE_TEMPLATE("cylinder", T, float, double) {
               CylinderCollection<T> cylinders{*centers, *semi_axes_a, *semi_axes_b, *heights, *rotations};
 
               const bool true_hit = false;
-              const unsigned int true_prim_id = -1;
+              const unsigned int true_prim_id = static_cast<unsigned int>(-1);
               const T true_distance = std::numeric_limits<T>::max();
               const Vec3r<T> true_normal{0, 0, 0};
               SUBCASE("intersect primitive") {
@@ -749,7 +749,7 @@ TEST_CASE_TEMPLATE("cylinder", T, float, double) {
               CylinderCollection<T> cylinders{*centers, *semi_axes_a, *semi_axes_b, *heights, *rotations};
 
               const bool true_hit = false;
-              const unsigned int true_prim_id = -1;
+              const unsigned int true_prim_id = static_cast<unsigned int>(-1);
               const T true_distance = std::numeric_limits<T>::max();
               const Vec3r<T> true_normal{0, 0, 0};
               SUBCASE("intersect primitive") {
@@ -766,7 +766,7 @@ TEST_CASE_TEMPLATE("cylinder", T, float, double) {
               CylinderCollection<T> cylinders{*centers, *semi_axes_a, *semi_axes_b, *heights, *rotations};
 
               const bool true_hit = false;
-              const unsigned int true_prim_id = -1;
+              const unsigned int true_prim_id = static_cast<unsigned int>(-1);
               const T true_distance = std::numeric_limits<T>::max();
               const Vec3r<T> true_normal{0, 0, 0};
               SUBCASE("intersect primitive") {
@@ -786,7 +786,7 @@ TEST_CASE_TEMPLATE("cylinder", T, float, double) {
                 CylinderCollection<T> cylinders{*centers, *semi_axes_a, *semi_axes_b, *heights, *rotations};
 
                 const bool true_hit = false;
-                const unsigned int true_prim_id = -1;
+                const unsigned int true_prim_id = static_cast<unsigned int>(-1);
                 const T true_distance = std::numeric_limits<T>::max();
                 const Vec3r<T> true_normal{0, 0, 0};
                 SUBCASE("intersect primitive") {
@@ -803,7 +803,7 @@ TEST_CASE_TEMPLATE("cylinder", T, float, double) {
                 CylinderCollection<T> cylinders{*centers, *semi_axes_a, *semi_axes_b, *heights, *rotations};
 
                 const bool true_hit = false;
-                const unsigned int true_prim_id = -1;
+                const unsigned int true_prim_id = static_cast<unsigned int>(-1);
                 const T true_distance = std::numeric_limits<T>::max();
                 const Vec3r<T> true_normal{0, 0, 0};
                 SUBCASE("intersect primitive") {
@@ -820,7 +820,7 @@ TEST_CASE_TEMPLATE("cylinder", T, float, double) {
                 CylinderCollection<T> cylinders{*centers, *semi_axes_a, *semi_axes_b, *heights, *rotations};
 
                 const bool true_hit = false;
-                const unsigned int true_prim_id = -1;
+                const unsigned int true_prim_id = static_cast<unsigned int>(-1);
                 const T true_distance = std::numeric_limits<T>::max();
                 const Vec3r<T> true_normal{0, 0, 0};
                 SUBCASE("intersect primitive") {
@@ -837,7 +837,7 @@ TEST_CASE_TEMPLATE("cylinder", T, float, double) {
                 CylinderCollection<T> cylinders{*centers, *semi_axes_a, *semi_axes_b, *heights, *rotations};
 
                 const bool true_hit = false;
-                const unsigned int true_prim_id = -1;
+                const unsigned int true_prim_id = static_cast<unsigned int>(-1);
                 const T true_distance = std::numeric_limits<T>::max();
                 const Vec3r<T> true_normal{0, 0, 0};
                 SUBCASE("intersect primitive") {
@@ -934,7 +934,7 @@ TEST_CASE_TEMPLATE("cylinder", T, float, double) {
             CylinderCollection<T> cylinders{*centers, *semi_axes_a, *semi_axes_b, *heights, *rotations};
 
             const bool true_hit = false;
-            const unsigned int true_prim_id = -1;
+            const unsigned int true_prim_id = static_cast<unsigned int>(-1);
             const T true_distance = std::numeric_limits<T>::max();
             const Vec3r<T> true_normal{0, 0, 0};
             SUBCASE("intersect primitive") {
@@ -956,7 +956,7 @@ TEST_CASE_TEMPLATE("cylinder", T, float, double) {
             CylinderCollection<T> cylinders{*centers, *semi_axes_a, *semi_axes_b, *heights, *rotations};
 
             const bool true_hit = false;
-            const unsigned int true_prim_id = -1;
+            const unsigned int true_prim_id = static_cast<unsigned int>(-1);
             const T true_distance = std::numeric_limits<T>::max();
             const Vec3r<T> true_normal{0, 0, 0};
             SUBCASE("intersect primitive") {
@@ -978,7 +978,7 @@ TEST_CASE_TEMPLATE("cylinder", T, float, double) {
             CylinderCollection<T> cylinders{*centers, *semi_axes_a, *semi_axes_b, *heights, *rotations};
 
             const bool true_hit = false;
-            const unsigned int true_prim_id = -1;
+            const unsigned int true_prim_id = static_cast<unsigned int>(-1);
             const T true_distance = std::numeric_limits<T>::max();
             const Vec3r<T> true_normal{0, 0, 0};
             SUBCASE("intersect primitive") {
@@ -1401,7 +1401,7 @@ TEST_CASE_TEMPLATE("cylinder", T, float, double) {
               CylinderCollection<T> cylinders{*centers, *semi_axes_a, *semi_axes_b, *heights, *rotations};
 
               const bool true_hit = false;
-              const unsigned int true_prim_id = -1;
+              const unsigned int true_prim_id = static_cast<unsigned int>(-1);
               const T true_distance = std::numeric_limits<T>::max();
               const Vec3r<T> true_normal{0, 0, 0};
               SUBCASE("intersect primitive") {
@@ -1419,7 +1419,7 @@ TEST_CASE_TEMPLATE("cylinder", T, float, double) {
               CylinderCollection<T> cylinders{*centers, *semi_axes_a, *semi_axes_b, *heights, *rotations};
 
               const bool true_hit = false;
-              const unsigned int true_prim_id = -1;
+              const unsigned int true_prim_id = static_cast<unsigned int>(-1);
               const T true_distance = std::numeric_limits<T>::max();
               const Vec3r<T> true_normal{0, 0, 0};
               SUBCASE("intersect primitive") {
@@ -1436,7 +1436,7 @@ TEST_CASE_TEMPLATE("cylinder", T, float, double) {
               CylinderCollection<T> cylinders{*centers, *semi_axes_a, *semi_axes_b, *heights, *rotations};
 
               const bool true_hit = false;
-              const unsigned int true_prim_id = -1;
+              const unsigned int true_prim_id = static_cast<unsigned int>(-1);
               const T true_distance = std::numeric_limits<T>::max();
               const Vec3r<T> true_normal{0, 0, 0};
               SUBCASE("intersect primitive") {
@@ -1453,7 +1453,7 @@ TEST_CASE_TEMPLATE("cylinder", T, float, double) {
               CylinderCollection<T> cylinders{*centers, *semi_axes_a, *semi_axes_b, *heights, *rotations};
 
               const bool true_hit = false;
-              const unsigned int true_prim_id = -1;
+              const unsigned int true_prim_id = static_cast<unsigned int>(-1);
               const T true_distance = std::numeric_limits<T>::max();
               const Vec3r<T> true_normal{0, 0, 0};
               SUBCASE("intersect primitive") {
@@ -1470,7 +1470,7 @@ TEST_CASE_TEMPLATE("cylinder", T, float, double) {
               CylinderCollection<T> cylinders{*centers, *semi_axes_a, *semi_axes_b, *heights, *rotations};
 
               const bool true_hit = false;
-              const unsigned int true_prim_id = -1;
+              const unsigned int true_prim_id = static_cast<unsigned int>(-1);
               const T true_distance = std::numeric_limits<T>::max();
               const Vec3r<T> true_normal{0, 0, 0};
               SUBCASE("intersect primitive") {
@@ -1487,7 +1487,7 @@ TEST_CASE_TEMPLATE("cylinder", T, float, double) {
               CylinderCollection<T> cylinders{*centers, *semi_axes_a, *semi_axes_b, *heights, *rotations};
 
               const bool true_hit = false;
-              const unsigned int true_prim_id = -1;
+              const unsigned int true_prim_id = static_cast<unsigned int>(-1);
               const T true_distance = std::numeric_limits<T>::max();
               const Vec3r<T> true_normal{0, 0, 0};
               SUBCASE("intersect primitive") {
@@ -1507,7 +1507,7 @@ TEST_CASE_TEMPLATE("cylinder", T, float, double) {
               CylinderCollection<T> cylinders{*centers, *semi_axes_a, *semi_axes_b, *heights, *rotations};
 
               const bool true_hit = false;
-              const unsigned int true_prim_id = -1;
+              const unsigned int true_prim_id = static_cast<unsigned int>(-1);
               const T true_distance = std::numeric_limits<T>::max();
               const Vec3r<T> true_normal{0, 0, 0};
               SUBCASE("intersect primitive") {
@@ -1525,7 +1525,7 @@ TEST_CASE_TEMPLATE("cylinder", T, float, double) {
               CylinderCollection<T> cylinders{*centers, *semi_axes_a, *semi_axes_b, *heights, *rotations};
 
               const bool true_hit = false;
-              const unsigned int true_prim_id = -1;
+              const unsigned int true_prim_id = static_cast<unsigned int>(-1);
               const T true_distance = std::numeric_limits<T>::max();
               const Vec3r<T> true_normal{0, 0, 0};
               SUBCASE("intersect primitive") {
@@ -1542,7 +1542,7 @@ TEST_CASE_TEMPLATE("cylinder", T, float, double) {
               CylinderCollection<T> cylinders{*centers, *semi_axes_a, *semi_axes_b, *heights, *rotations};
 
               const bool true_hit = false;
-              const unsigned int true_prim_id = -1;
+              const unsigned int true_prim_id = static_cast<unsigned int>(-1);
               const T true_distance = std::numeric_limits<T>::max();
               const Vec3r<T> true_normal{0, 0, 0};
               SUBCASE("intersect primitive") {
@@ -1559,7 +1559,7 @@ TEST_CASE_TEMPLATE("cylinder", T, float, double) {
               CylinderCollection<T> cylinders{*centers, *semi_axes_a, *semi_axes_b, *heights, *rotations};
 
               const bool true_hit = false;
-              const unsigned int true_prim_id = -1;
+              const unsigned int true_prim_id = static_cast<unsigned int>(-1);
               const T true_distance = std::numeric_limits<T>::max();
               const Vec3r<T> true_normal{0, 0, 0};
               SUBCASE("intersect primitive") {
@@ -1576,7 +1576,7 @@ TEST_CASE_TEMPLATE("cylinder", T, float, double) {
               CylinderCollection<T> cylinders{*centers, *semi_axes_a, *semi_axes_b, *heights, *rotations};
 
               const bool true_hit = false;
-              const unsigned int true_prim_id = -1;
+              const unsigned int true_prim_id = static_cast<unsigned int>(-1);
               const T true_distance = std::numeric_limits<T>::max();
               const Vec3r<T> true_normal{0, 0, 0};
               SUBCASE("intersect primitive") {
@@ -1593,7 +1593,7 @@ TEST_CASE_TEMPLATE("cylinder", T, float, double) {
               CylinderCollection<T> cylinders{*centers, *semi_axes_a, *semi_axes_b, *heights, *rotations};
 
               const bool true_hit = false;
-              const unsigned int true_prim_id = -1;
+              const unsigned int true_prim_id = static_cast<unsigned int>(-1);
               const T true_distance = std::numeric_limits<T>::max();
               const Vec3r<T> true_normal{0, 0, 0};
               SUBCASE("intersect primitive") {
@@ -1613,7 +1613,7 @@ TEST_CASE_TEMPLATE("cylinder", T, float, double) {
                 CylinderCollection<T> cylinders{*centers, *semi_axes_a, *semi_axes_b, *heights, *rotations};
 
                 const bool true_hit = false;
-                const unsigned int true_prim_id = -1;
+                const unsigned int true_prim_id = static_cast<unsigned int>(-1);
                 const T true_distance = std::numeric_limits<T>::max();
                 const Vec3r<T> true_normal{0, 0, 0};
                 SUBCASE("intersect primitive") {
@@ -1630,7 +1630,7 @@ TEST_CASE_TEMPLATE("cylinder", T, float, double) {
                 CylinderCollection<T> cylinders{*centers, *semi_axes_a, *semi_axes_b, *heights, *rotations};
 
                 const bool true_hit = false;
-                const unsigned int true_prim_id = -1;
+                const unsigned int true_prim_id = static_cast<unsigned int>(-1);
                 const T true_distance = std::numeric_limits<T>::max();
                 const Vec3r<T> true_normal{0, 0, 0};
                 SUBCASE("intersect primitive") {
@@ -1647,7 +1647,7 @@ TEST_CASE_TEMPLATE("cylinder", T, float, double) {
                 CylinderCollection<T> cylinders{*centers, *semi_axes_a, *semi_axes_b, *heights, *rotations};
 
                 const bool true_hit = false;
-                const unsigned int true_prim_id = -1;
+                const unsigned int true_prim_id = static_cast<unsigned int>(-1);
                 const T true_distance = std::numeric_limits<T>::max();
                 const Vec3r<T> true_normal{0, 0, 0};
                 SUBCASE("intersect primitive") {
@@ -1664,7 +1664,7 @@ TEST_CASE_TEMPLATE("cylinder", T, float, double) {
                 CylinderCollection<T> cylinders{*centers, *semi_axes_a, *semi_axes_b, *heights, *rotations};
 
                 const bool true_hit = false;
-                const unsigned int true_prim_id = -1;
+                const unsigned int true_prim_id = static_cast<unsigned int>(-1);
                 const T true_distance = std::numeric_limits<T>::max();
                 const Vec3r<T> true_normal{0, 0, 0};
                 SUBCASE("intersect primitive") {
@@ -1760,7 +1760,7 @@ TEST_CASE_TEMPLATE("cylinder", T, float, double) {
             CylinderCollection<T> cylinders{*centers, *semi_axes_a, *semi_axes_b, *heights, *rotations};
 
             const bool true_hit = false;
-            const unsigned int true_prim_id = -1;
+            const unsigned int true_prim_id = static_cast<unsigned int>(-1);
             const T true_distance = std::numeric_limits<T>::max();
             const Vec3r<T> true_normal{0, 0, 0};
             SUBCASE("intersect primitive") {
@@ -1782,7 +1782,7 @@ TEST_CASE_TEMPLATE("cylinder", T, float, double) {
             CylinderCollection<T> cylinders{*centers, *semi_axes_a, *semi_axes_b, *heights, *rotations};
 
             const bool true_hit = false;
-            const unsigned int true_prim_id = -1;
+            const unsigned int true_prim_id = static_cast<unsigned int>(-1);
             const T true_distance = std::numeric_limits<T>::max();
             const Vec3r<T> true_normal{0, 0, 0};
             SUBCASE("intersect primitive") {
@@ -1804,7 +1804,7 @@ TEST_CASE_TEMPLATE("cylinder", T, float, double) {
             CylinderCollection<T> cylinders{*centers, *semi_axes_a, *semi_axes_b, *heights, *rotations};
 
             const bool true_hit = false;
-            const unsigned int true_prim_id = -1;
+            const unsigned int true_prim_id = static_cast<unsigned int>(-1);
             const T true_distance = std::numeric_limits<T>::max();
             const Vec3r<T> true_normal{0, 0, 0};
             SUBCASE("intersect primitive") {

--- a/test/test_primitives/test_sphere.cpp
+++ b/test/test_primitives/test_sphere.cpp
@@ -184,7 +184,7 @@ TEST_CASE_TEMPLATE("Sphere", T, float, double) {
         SphereCollection spheres(*centers, *radii);
 
         const bool true_hit = false;
-        const unsigned int true_prim_id = -1;
+        const unsigned int true_prim_id = static_cast<unsigned int>(-1);
         const T true_distance = std::numeric_limits<T>::max();
         const Vec3r<T> true_normal{0, 0, 0};
 


### PR DESCRIPTION
## Status
**READY**

## Description
I cleaned up the construction of a ray object by introducing enum classes to replace the boolean values. This follows the advice from [here](https://www.youtube.com/watch?v=nLSm3Haxz0I) and seems completely reasonable. 

The enum classes are public member of the Ray<T> class and are defined as follows:
```C++
class BLAZERTALIGN Ray {
public:
  enum class CullBackFace { yes, no };
  enum class AnyHit { yes, no };
...
}
```

What we should talk about it the yes and no option, but I couldn't come up with something better. Maybe "on" and "off" are better alternatives. 

I also introduced an issue template for enhancements, which are not necessarily feature requests. 

## Type of Change
- [ ] bug fix 
- [ ] new features
- [ ] documentation
- [x] other 

## How to test the PR
A few words describing how to use and test the changes made in the PR.

## Checklist
- [x] I have run the provided clang-format
- [x] I have reviewed my code and commented if necessary
- [x] I have added the appropriate documentation
- [ ] I have added tests to my new code
- [x] All tests pass locally
