### PR TITLE
operator<< for geometry primitives in JSON format for debug purposes

### DIFF
--- a/blazert/bvh/node.h
+++ b/blazert/bvh/node.h
@@ -37,11 +37,11 @@ public:
 template<typename T, template<typename> typename Collection>
 std::ostream &operator<<(std::ostream &stream, const BVHNode<T, Collection> &node) {
   stream << "{\n";
-  stream << "  node: " << &node << ",\n";
-  stream << "  min: [" << node.min[0] << ", " << node.min[1] << ", " << node.min[2] << "],\n";
-  stream << "  max: [" << node.max[0] << ", " << node.max[1] << ", " << node.max[2] << "],\n";
-  stream << "  leaf: " << node.leaf << ",\n";
-  stream << "  axis: " << node.axis << "\n";
+  stream << R"(  "node": )" << &node << ",\n";
+  stream << R"(  "min:" [)" << node.min[0] << ", " << node.min[1] << ", " << node.min[2] << "],\n";
+  stream << R"(  "max:" [)" << node.max[0] << ", " << node.max[1] << ", " << node.max[2] << "],\n";
+  stream << R"(  "leaf": )" << node.leaf << ",\n";
+  stream << R"(  "axis": )" << node.axis << "\n";
   stream << "}\n";
   return stream;
 }

--- a/blazert/embree/primitives/EmbreeCylinder.h
+++ b/blazert/embree/primitives/EmbreeCylinder.h
@@ -548,5 +548,30 @@ inline void cylinderOccludedFunc(const RTCOccludedFunctionNArguments *args) {
   }
 }
 
+inline std::ostream &operator<<(std::ostream &stream, const EmbreeCylinder &cylinder) {
+  /// Conveniently output a single plane as JSON.
+  stream << "{\n";
+
+  stream << R"(  "EmbreeCylinder": )" << &cylinder
+         << ",\n";
+  stream << R"(  "cylinder": [)"
+         << cylinder.center[0] << "," << cylinder.center[1] << "," << cylinder.center[2] << "],\n";
+  stream << R"(  "a": )" << cylinder.a
+         << "\n";
+  stream << R"(  "b": )" << cylinder.b
+         << "\n";
+  stream << R"(  "height": )" << cylinder.height
+         << "\n";
+  stream << R"(  "rotation": [[)" << cylinder.rotMatrix(0, 0) << ", " << cylinder.rotMatrix(0, 1) << ", " << cylinder.rotMatrix(0, 2)
+         << "],\n"
+         << "             [" << cylinder.rotMatrix(1, 0) << ", " << cylinder.rotMatrix(1, 1) << ", " << cylinder.rotMatrix(1, 2)
+         << "],\n"
+         << "             [" << cylinder.rotMatrix(2, 0) << ", " << cylinder.rotMatrix(2, 1) << ", " << cylinder.rotMatrix(2, 2)
+         << "]],\n";
+
+  stream << "}\n";
+  return stream;
+}
+
 }// namespace blazert
 #endif// BLAZERT_EMBREECYLINDER_H

--- a/blazert/embree/primitives/EmbreePlane.h
+++ b/blazert/embree/primitives/EmbreePlane.h
@@ -263,6 +263,29 @@ inline void planeOccludedFunc(const RTCOccludedFunctionNArguments *args) {
   }
 }
 
+inline std::ostream &operator<<(std::ostream &stream, const EmbreePlane &plane) {
+  /// Conveniently output a single plane as JSON.
+  stream << "{\n";
+
+  stream << R"(  "EmbreePlane": )" << &plane
+         << ",\n";
+  stream << R"(  "center": [)"
+         << plane.planeCenter[0] << "," << plane.planeCenter[1] << "," << plane.planeCenter[2] << "],\n";
+  stream << R"(  "d1": )" << plane.d1
+         << "\n";
+  stream << R"(  "d2": )" << plane.d2
+         << "\n";
+  stream << R"(  "rotation": [[)" << plane.rot(0, 0) << ", " << plane.rot(0, 1) << ", " << plane.rot(0, 2)
+         << "],\n"
+         << "             [" << plane.rot(1, 0) << ", " << plane.rot(1, 1) << ", " << plane.rot(1, 2)
+         << "],\n"
+         << "             [" << plane.rot(2, 0) << ", " << plane.rot(2, 1) << ", " << plane.rot(2, 2)
+         << "]],\n";
+
+  stream << "}\n";
+  return stream;
+}
+
 }// namespace blazert
 
 #endif// BLAZERT_EMBREEPLANE_H

--- a/blazert/embree/primitives/EmbreeSphere.h
+++ b/blazert/embree/primitives/EmbreeSphere.h
@@ -187,6 +187,21 @@ inline void sphereOccludedFunc(const RTCOccludedFunctionNArguments *args) {
   }
 }
 
+inline std::ostream &operator<<(std::ostream &stream, const EmbreeSphere &sphere) {
+  /// Conveniently output a single plane as JSON.
+  stream << "{\n";
+
+  stream << R"(  "EmbreeSphere": )" << &sphere
+         << ",\n";
+  stream << R"(  "center": [)"
+         << sphere.center[0] << "," << sphere.center[1] << "," << sphere.center[2] << "],\n";
+  stream << R"(  "radius": )" << sphere.radius
+         << "\n";
+
+  stream << "}\n";
+  return stream;
+}
+
 }// namespace blazert
 
 #endif// EM_EMBREESPHERE_H

--- a/blazert/primitives/cylinder.h
+++ b/blazert/primitives/cylinder.h
@@ -499,18 +499,18 @@ std::ostream &operator<<(std::ostream &stream, const Cylinder<T> &cylinder) {
   /// Conveniently output a single cylinder as JSON.
   stream << "{\n";
 
-  stream << "  Cylinder: " << &cylinder << ",\n";
-  stream << "  center: [" << cylinder.center[0] << "," << cylinder.center[1] << "," << cylinder.center[2] << "],\n";
-  stream << "  semi_axis_a: " << cylinder.semi_axis_a << ",\n";
-  stream << "  semi_axis_b: " << cylinder.semi_axis_b << ",\n";
-  stream << "  height: " << cylinder.height << ",\n";
-  stream << "  rotation: [[" << cylinder.rotation(0, 0) << ", " << cylinder.rotation(0, 1) << ", "
+  stream << R"(  "Cylinder": )" << &cylinder << ",\n";
+  stream << R"(  "center": [)" << cylinder.center[0] << "," << cylinder.center[1] << "," << cylinder.center[2] << "],\n";
+  stream << R"(  "semi_axis_a": )" << cylinder.semi_axis_a << ",\n";
+  stream << R"(  "semi_axis_b": )" << cylinder.semi_axis_b << ",\n";
+  stream << R"(  "height": )" << cylinder.height << ",\n";
+  stream << R"(  "rotation": [[)" << cylinder.rotation(0, 0) << ", " << cylinder.rotation(0, 1) << ", "
          << cylinder.rotation(0, 2) << "],\n"
          << "             [" << cylinder.rotation(1, 0) << ", " << cylinder.rotation(1, 1) << ", "
          << cylinder.rotation(1, 2) << "],\n"
          << "             [" << cylinder.rotation(2, 0) << ", " << cylinder.rotation(2, 1) << ", "
          << cylinder.rotation(2, 2) << "]],\n";
-  stream << "  prim_id: " << cylinder.prim_id << "\n";
+  stream << R"(  "prim_id": )" << cylinder.prim_id << "\n";
 
   stream << "}\n";
   return stream;
@@ -519,8 +519,8 @@ std::ostream &operator<<(std::ostream &stream, const Cylinder<T> &cylinder) {
 template<typename T>
 std::ostream &operator<<(std::ostream &stream, const CylinderCollection<T> &collection) {
   stream << "{\n";
-  stream << "CylinderCollection: [\n";
-  stream << "  size: " << collection.size() << ",\n";
+  stream << R"("CylinderCollection": [)" << "\n";
+  stream << R"({ "size": )" << collection.size() << "},\n";
 
   for (uint32_t id_cylinder = 0; id_cylinder < collection.size(); id_cylinder++) {
     stream << primitive_from_collection(collection, id_cylinder);

--- a/blazert/primitives/cylinder.h
+++ b/blazert/primitives/cylinder.h
@@ -49,9 +49,12 @@ std::ostream &operator<<(std::ostream &stream, const Cylinder<T> &cylinder) {
   stream << "  semi_axis_a: " << cylinder.semi_axis_a << ",\n";
   stream << "  semi_axis_b: " << cylinder.semi_axis_b << ",\n";
   stream << "  height: " << cylinder.height << ",\n";
-  stream << "  rotation: [[" << cylinder.rotation(0,0) << ", " << cylinder.rotation(0,1) << ", "<< cylinder.rotation(0,2) << "],\n"
-         << "             [" << cylinder.rotation(1,0) << ", " << cylinder.rotation(1,1) << ", "<< cylinder.rotation(1,2) << "],\n"
-         << "             [" << cylinder.rotation(2,0) << ", " << cylinder.rotation(2,1) << ", "<< cylinder.rotation(2,2) << "]],\n";
+  stream << "  rotation: [[" << cylinder.rotation(0, 0) << ", " << cylinder.rotation(0, 1) << ", "
+         << cylinder.rotation(0, 2) << "],\n"
+         << "             [" << cylinder.rotation(1, 0) << ", " << cylinder.rotation(1, 1) << ", "
+         << cylinder.rotation(1, 2) << "],\n"
+         << "             [" << cylinder.rotation(2, 0) << ", " << cylinder.rotation(2, 1) << ", "
+         << cylinder.rotation(2, 2) << "]],\n";
   stream << "  prim_id: " << cylinder.prim_id << "\n";
 
   stream << "}\n";
@@ -167,14 +170,14 @@ private:
 };
 
 template<typename T>
-std::ostream &operator<<(std::ostream& stream, const CylinderCollection<T> &collection) {
+std::ostream &operator<<(std::ostream &stream, const CylinderCollection<T> &collection) {
   stream << "{\n";
   stream << "CylinderCollection: [\n";
   stream << "  size: " << collection.size() << ",\n";
 
-  for(uint32_t id_cylinder = 0; id_cylinder < collection.size(); id_cylinder++){
+  for (uint32_t id_cylinder = 0; id_cylinder < collection.size(); id_cylinder++) {
     stream << primitive_from_collection(collection, id_cylinder);
-    if(id_cylinder == collection.size() - 1) {
+    if (id_cylinder == collection.size() - 1) {
       stream << "]\n";
     } else {
       stream << ", \n";

--- a/blazert/primitives/cylinder.h
+++ b/blazert/primitives/cylinder.h
@@ -39,28 +39,6 @@ public:
   Cylinder &operator=(const Cylinder &rhs) = delete;
 };
 
-template<typename T>
-std::ostream &operator<<(std::ostream &stream, const Cylinder<T> &cylinder) {
-  /// Conveniently output a single cylinder as JSON.
-  stream << "{\n";
-
-  stream << "  Cylinder: " << &cylinder << ",\n";
-  stream << "  center: [" << cylinder.center[0] << "," << cylinder.center[1] << "," << cylinder.center[2] << "],\n";
-  stream << "  semi_axis_a: " << cylinder.semi_axis_a << ",\n";
-  stream << "  semi_axis_b: " << cylinder.semi_axis_b << ",\n";
-  stream << "  height: " << cylinder.height << ",\n";
-  stream << "  rotation: [[" << cylinder.rotation(0, 0) << ", " << cylinder.rotation(0, 1) << ", "
-         << cylinder.rotation(0, 2) << "],\n"
-         << "             [" << cylinder.rotation(1, 0) << ", " << cylinder.rotation(1, 1) << ", "
-         << cylinder.rotation(1, 2) << "],\n"
-         << "             [" << cylinder.rotation(2, 0) << ", " << cylinder.rotation(2, 1) << ", "
-         << cylinder.rotation(2, 2) << "]],\n";
-  stream << "  prim_id: " << cylinder.prim_id << "\n";
-
-  stream << "}\n";
-  return stream;
-}
-
 template<typename T, template<typename A> typename Collection,
          typename = std::enable_if_t<std::is_same<typename Collection<T>::primitive_type, Cylinder<T>>::value>>
 [[nodiscard]] inline Cylinder<T> primitive_from_collection(const Collection<T> &collection,
@@ -168,25 +146,6 @@ private:
     return std::make_pair(std::move(min), std::move(max));
   }
 };
-
-template<typename T>
-std::ostream &operator<<(std::ostream &stream, const CylinderCollection<T> &collection) {
-  stream << "{\n";
-  stream << "CylinderCollection: [\n";
-  stream << "  size: " << collection.size() << ",\n";
-
-  for (uint32_t id_cylinder = 0; id_cylinder < collection.size(); id_cylinder++) {
-    stream << primitive_from_collection(collection, id_cylinder);
-    if (id_cylinder == collection.size() - 1) {
-      stream << "]\n";
-    } else {
-      stream << ", \n";
-    }
-  }
-
-  stream << "}\n";
-  return stream;
-}
 
 /**
  * Post BVH traversal stuff.
@@ -533,6 +492,47 @@ inline bool intersect_primitive(CylinderIntersector<T, Collection> &i, const Cyl
   }
 
   return false;
+}
+
+template<typename T>
+std::ostream &operator<<(std::ostream &stream, const Cylinder<T> &cylinder) {
+  /// Conveniently output a single cylinder as JSON.
+  stream << "{\n";
+
+  stream << "  Cylinder: " << &cylinder << ",\n";
+  stream << "  center: [" << cylinder.center[0] << "," << cylinder.center[1] << "," << cylinder.center[2] << "],\n";
+  stream << "  semi_axis_a: " << cylinder.semi_axis_a << ",\n";
+  stream << "  semi_axis_b: " << cylinder.semi_axis_b << ",\n";
+  stream << "  height: " << cylinder.height << ",\n";
+  stream << "  rotation: [[" << cylinder.rotation(0, 0) << ", " << cylinder.rotation(0, 1) << ", "
+         << cylinder.rotation(0, 2) << "],\n"
+         << "             [" << cylinder.rotation(1, 0) << ", " << cylinder.rotation(1, 1) << ", "
+         << cylinder.rotation(1, 2) << "],\n"
+         << "             [" << cylinder.rotation(2, 0) << ", " << cylinder.rotation(2, 1) << ", "
+         << cylinder.rotation(2, 2) << "]],\n";
+  stream << "  prim_id: " << cylinder.prim_id << "\n";
+
+  stream << "}\n";
+  return stream;
+}
+
+template<typename T>
+std::ostream &operator<<(std::ostream &stream, const CylinderCollection<T> &collection) {
+  stream << "{\n";
+  stream << "CylinderCollection: [\n";
+  stream << "  size: " << collection.size() << ",\n";
+
+  for (uint32_t id_cylinder = 0; id_cylinder < collection.size(); id_cylinder++) {
+    stream << primitive_from_collection(collection, id_cylinder);
+    if (id_cylinder == collection.size() - 1) {
+      stream << "]\n";
+    } else {
+      stream << ", \n";
+    }
+  }
+
+  stream << "}\n";
+  return stream;
 }
 
 }// namespace blazert

--- a/blazert/primitives/cylinder.h
+++ b/blazert/primitives/cylinder.h
@@ -39,6 +39,25 @@ public:
   Cylinder &operator=(const Cylinder &rhs) = delete;
 };
 
+template<typename T>
+std::ostream &operator<<(std::ostream &stream, const Cylinder<T> &cylinder) {
+  /// Conveniently output a single cylinder as JSON.
+  stream << "{\n";
+
+  stream << "  Cylinder: " << &cylinder << ",\n";
+  stream << "  center: [" << cylinder.center[0] << "," << cylinder.center[1] << "," << cylinder.center[2] << "],\n";
+  stream << "  semi_axis_a: " << cylinder.semi_axis_a << ",\n";
+  stream << "  semi_axis_b: " << cylinder.semi_axis_b << ",\n";
+  stream << "  height: " << cylinder.height << ",\n";
+  stream << "  rotation: [[" << cylinder.rotation(0,0) << ", " << cylinder.rotation(0,1) << ", "<< cylinder.rotation(0,2) << "],\n"
+         << "             [" << cylinder.rotation(1,0) << ", " << cylinder.rotation(1,1) << ", "<< cylinder.rotation(1,2) << "],\n"
+         << "             [" << cylinder.rotation(2,0) << ", " << cylinder.rotation(2,1) << ", "<< cylinder.rotation(2,2) << "]],\n";
+  stream << "  prim_id: " << cylinder.prim_id << "\n";
+
+  stream << "}\n";
+  return stream;
+}
+
 template<typename T, template<typename A> typename Collection,
          typename = std::enable_if_t<std::is_same<typename Collection<T>::primitive_type, Cylinder<T>>::value>>
 [[nodiscard]] inline Cylinder<T> primitive_from_collection(const Collection<T> &collection,
@@ -146,6 +165,25 @@ private:
     return std::make_pair(std::move(min), std::move(max));
   }
 };
+
+template<typename T>
+std::ostream &operator<<(std::ostream& stream, const CylinderCollection<T> &collection) {
+  stream << "{\n";
+  stream << "CylinderCollection: [\n";
+  stream << "  size: " << collection.size() << ",\n";
+
+  for(uint32_t id_cylinder = 0; id_cylinder < collection.size(); id_cylinder++){
+    stream << primitive_from_collection(collection, id_cylinder);
+    if(id_cylinder == collection.size() - 1) {
+      stream << "]\n";
+    } else {
+      stream << ", \n";
+    }
+  }
+
+  stream << "}\n";
+  return stream;
+}
 
 /**
  * Post BVH traversal stuff.

--- a/blazert/primitives/plane.h
+++ b/blazert/primitives/plane.h
@@ -47,9 +47,12 @@ std::ostream &operator<<(std::ostream &stream, const Plane<T> &plane) {
   stream << "  center: [" << plane.center[0] << "," << plane.center[1] << "," << plane.center[2] << "],\n";
   stream << "  dx: " << plane.dx << ",\n";
   stream << "  dy: " << plane.dy << ",\n";
-  stream << "  rotation: [[" << plane.rotation(0,0) << ", " << plane.rotation(0,1) << ", "<< plane.rotation(0,2) << "],\n"
-         << "             [" << plane.rotation(1,0) << ", " << plane.rotation(1,1) << ", "<< plane.rotation(1,2) << "],\n"
-         << "             [" << plane.rotation(2,0) << ", " << plane.rotation(2,1) << ", "<< plane.rotation(2,2) << "]],\n";
+  stream << "  rotation: [[" << plane.rotation(0, 0) << ", " << plane.rotation(0, 1) << ", " << plane.rotation(0, 2)
+         << "],\n"
+         << "             [" << plane.rotation(1, 0) << ", " << plane.rotation(1, 1) << ", " << plane.rotation(1, 2)
+         << "],\n"
+         << "             [" << plane.rotation(2, 0) << ", " << plane.rotation(2, 1) << ", " << plane.rotation(2, 2)
+         << "]],\n";
   stream << "  prim_id: " << plane.prim_id << "\n";
 
   stream << "}\n";
@@ -169,14 +172,14 @@ private:
 };
 
 template<typename T>
-std::ostream &operator<<(std::ostream& stream, const PlaneCollection<T> &collection) {
+std::ostream &operator<<(std::ostream &stream, const PlaneCollection<T> &collection) {
   stream << "{\n";
   stream << "PlaneCollection: [\n";
   stream << "  size: " << collection.size() << ",\n";
 
-  for(uint32_t id_plane = 0; id_plane < collection.size(); id_plane++){
+  for (uint32_t id_plane = 0; id_plane < collection.size(); id_plane++) {
     stream << primitive_from_collection(collection, id_plane);
-    if(id_plane == collection.size() - 1) {
+    if (id_plane == collection.size() - 1) {
       stream << "]\n";
     } else {
       stream << ", \n";

--- a/blazert/primitives/plane.h
+++ b/blazert/primitives/plane.h
@@ -38,27 +38,6 @@ public:
   Plane &operator=(const Plane &rhs) = delete;
 };
 
-template<typename T>
-std::ostream &operator<<(std::ostream &stream, const Plane<T> &plane) {
-  /// Conveniently output a single plane as JSON.
-  stream << "{\n";
-
-  stream << "  Plane: " << &plane << ",\n";
-  stream << "  center: [" << plane.center[0] << "," << plane.center[1] << "," << plane.center[2] << "],\n";
-  stream << "  dx: " << plane.dx << ",\n";
-  stream << "  dy: " << plane.dy << ",\n";
-  stream << "  rotation: [[" << plane.rotation(0, 0) << ", " << plane.rotation(0, 1) << ", " << plane.rotation(0, 2)
-         << "],\n"
-         << "             [" << plane.rotation(1, 0) << ", " << plane.rotation(1, 1) << ", " << plane.rotation(1, 2)
-         << "],\n"
-         << "             [" << plane.rotation(2, 0) << ", " << plane.rotation(2, 1) << ", " << plane.rotation(2, 2)
-         << "]],\n";
-  stream << "  prim_id: " << plane.prim_id << "\n";
-
-  stream << "}\n";
-  return stream;
-}
-
 template<typename T, template<typename A> typename Collection,
          typename = std::enable_if_t<std::is_same<typename Collection<T>::primitive_type, Plane<T>>::value>>
 [[nodiscard]] inline Plane<T> primitive_from_collection(const Collection<T> &collection, const unsigned int prim_idx) {
@@ -170,25 +149,6 @@ private:
     return std::make_pair(std::move(min), std::move(max));
   }
 };
-
-template<typename T>
-std::ostream &operator<<(std::ostream &stream, const PlaneCollection<T> &collection) {
-  stream << "{\n";
-  stream << "PlaneCollection: [\n";
-  stream << "  size: " << collection.size() << ",\n";
-
-  for (uint32_t id_plane = 0; id_plane < collection.size(); id_plane++) {
-    stream << primitive_from_collection(collection, id_plane);
-    if (id_plane == collection.size() - 1) {
-      stream << "]\n";
-    } else {
-      stream << ", \n";
-    }
-  }
-
-  stream << "}\n";
-  return stream;
-}
 
 template<typename T, template<typename> typename Collection>
 inline void post_traversal(PlaneIntersector<T, Collection> &i, RayHit<T> &rayhit) {
@@ -307,6 +267,47 @@ inline bool intersect_primitive(PlaneIntersector<T, Collection> &i, const Plane<
     return true;
   }
   return false;
+}
+
+
+template<typename T>
+std::ostream &operator<<(std::ostream &stream, const Plane<T> &plane) {
+  /// Conveniently output a single plane as JSON.
+  stream << "{\n";
+
+  stream << "  Plane: " << &plane << ",\n";
+  stream << "  center: [" << plane.center[0] << "," << plane.center[1] << "," << plane.center[2] << "],\n";
+  stream << "  dx: " << plane.dx << ",\n";
+  stream << "  dy: " << plane.dy << ",\n";
+  stream << "  rotation: [[" << plane.rotation(0, 0) << ", " << plane.rotation(0, 1) << ", " << plane.rotation(0, 2)
+         << "],\n"
+         << "             [" << plane.rotation(1, 0) << ", " << plane.rotation(1, 1) << ", " << plane.rotation(1, 2)
+         << "],\n"
+         << "             [" << plane.rotation(2, 0) << ", " << plane.rotation(2, 1) << ", " << plane.rotation(2, 2)
+         << "]],\n";
+  stream << "  prim_id: " << plane.prim_id << "\n";
+
+  stream << "}\n";
+  return stream;
+}
+
+template<typename T>
+std::ostream &operator<<(std::ostream &stream, const PlaneCollection<T> &collection) {
+  stream << "{\n";
+  stream << "PlaneCollection: [\n";
+  stream << "  size: " << collection.size() << ",\n";
+
+  for (uint32_t id_plane = 0; id_plane < collection.size(); id_plane++) {
+    stream << primitive_from_collection(collection, id_plane);
+    if (id_plane == collection.size() - 1) {
+      stream << "]\n";
+    } else {
+      stream << ", \n";
+    }
+  }
+
+  stream << "}\n";
+  return stream;
 }
 
 }// namespace blazert

--- a/blazert/primitives/plane.h
+++ b/blazert/primitives/plane.h
@@ -38,6 +38,24 @@ public:
   Plane &operator=(const Plane &rhs) = delete;
 };
 
+template<typename T>
+std::ostream &operator<<(std::ostream &stream, const Plane<T> &plane) {
+  /// Conveniently output a single plane as JSON.
+  stream << "{\n";
+
+  stream << "  Plane: " << &plane << ",\n";
+  stream << "  center: [" << plane.center[0] << "," << plane.center[1] << "," << plane.center[2] << "],\n";
+  stream << "  dx: " << plane.dx << ",\n";
+  stream << "  dy: " << plane.dy << ",\n";
+  stream << "  rotation: [[" << plane.rotation(0,0) << ", " << plane.rotation(0,1) << ", "<< plane.rotation(0,2) << "],\n"
+         << "             [" << plane.rotation(1,0) << ", " << plane.rotation(1,1) << ", "<< plane.rotation(1,2) << "],\n"
+         << "             [" << plane.rotation(2,0) << ", " << plane.rotation(2,1) << ", "<< plane.rotation(2,2) << "]],\n";
+  stream << "  prim_id: " << plane.prim_id << "\n";
+
+  stream << "}\n";
+  return stream;
+}
+
 template<typename T, template<typename A> typename Collection,
          typename = std::enable_if_t<std::is_same<typename Collection<T>::primitive_type, Plane<T>>::value>>
 [[nodiscard]] inline Plane<T> primitive_from_collection(const Collection<T> &collection, const unsigned int prim_idx) {
@@ -149,6 +167,25 @@ private:
     return std::make_pair(std::move(min), std::move(max));
   }
 };
+
+template<typename T>
+std::ostream &operator<<(std::ostream& stream, const PlaneCollection<T> &collection) {
+  stream << "{\n";
+  stream << "PlaneCollection: [\n";
+  stream << "  size: " << collection.size() << ",\n";
+
+  for(uint32_t id_plane = 0; id_plane < collection.size(); id_plane++){
+    stream << primitive_from_collection(collection, id_plane);
+    if(id_plane == collection.size() - 1) {
+      stream << "]\n";
+    } else {
+      stream << ", \n";
+    }
+  }
+
+  stream << "}\n";
+  return stream;
+}
 
 template<typename T, template<typename> typename Collection>
 inline void post_traversal(PlaneIntersector<T, Collection> &i, RayHit<T> &rayhit) {

--- a/blazert/primitives/plane.h
+++ b/blazert/primitives/plane.h
@@ -275,17 +275,17 @@ std::ostream &operator<<(std::ostream &stream, const Plane<T> &plane) {
   /// Conveniently output a single plane as JSON.
   stream << "{\n";
 
-  stream << "  Plane: " << &plane << ",\n";
-  stream << "  center: [" << plane.center[0] << "," << plane.center[1] << "," << plane.center[2] << "],\n";
-  stream << "  dx: " << plane.dx << ",\n";
-  stream << "  dy: " << plane.dy << ",\n";
-  stream << "  rotation: [[" << plane.rotation(0, 0) << ", " << plane.rotation(0, 1) << ", " << plane.rotation(0, 2)
+  stream << R"(  "Plane": )" << &plane << ",\n";
+  stream << R"(  "center": [)" << plane.center[0] << "," << plane.center[1] << "," << plane.center[2] << "],\n";
+  stream << R"(  "dx": )" << plane.dx << ",\n";
+  stream << R"(  "dy": )" << plane.dy << ",\n";
+  stream << R"(  "rotation": [[)" << plane.rotation(0, 0) << ", " << plane.rotation(0, 1) << ", " << plane.rotation(0, 2)
          << "],\n"
          << "             [" << plane.rotation(1, 0) << ", " << plane.rotation(1, 1) << ", " << plane.rotation(1, 2)
          << "],\n"
          << "             [" << plane.rotation(2, 0) << ", " << plane.rotation(2, 1) << ", " << plane.rotation(2, 2)
          << "]],\n";
-  stream << "  prim_id: " << plane.prim_id << "\n";
+  stream << R"(  "prim_id": )" << plane.prim_id << "\n";
 
   stream << "}\n";
   return stream;
@@ -294,8 +294,9 @@ std::ostream &operator<<(std::ostream &stream, const Plane<T> &plane) {
 template<typename T>
 std::ostream &operator<<(std::ostream &stream, const PlaneCollection<T> &collection) {
   stream << "{\n";
-  stream << "PlaneCollection: [\n";
-  stream << "  size: " << collection.size() << ",\n";
+  stream << R"("PlaneCollection": [)"
+         << "\n";
+  stream << R"({"size": )" << collection.size() << "},\n";
 
   for (uint32_t id_plane = 0; id_plane < collection.size(); id_plane++) {
     stream << primitive_from_collection(collection, id_plane);

--- a/blazert/primitives/sphere.h
+++ b/blazert/primitives/sphere.h
@@ -186,10 +186,14 @@ std::ostream &operator<<(std::ostream &stream, const Sphere<T> &sphere) {
   /// Conveniently output a single plane as JSON.
   stream << "{\n";
 
-  stream << "  Sphere: " << &sphere << ",\n";
-  stream << "  center: [" << sphere.center[0] << "," << sphere.center[1] << "," << sphere.center[2] << "],\n";
-  stream << "  radius: " << sphere.radius << ",\n";
-  stream << "  prim_id: " << sphere.prim_id << "\n";
+  stream << R"(  "Sphere": )" << &sphere
+         << ",\n";
+  stream << R"(  "center": [)"
+         << sphere.center[0] << "," << sphere.center[1] << "," << sphere.center[2] << "],\n";
+  stream << R"(  "radius": )" << sphere.radius
+         << ",\n";
+  stream << R"(  "prim_id": )" << sphere.prim_id
+         << "\n";
 
   stream << "}\n";
   return stream;
@@ -198,8 +202,9 @@ std::ostream &operator<<(std::ostream &stream, const Sphere<T> &sphere) {
 template<typename T>
 std::ostream &operator<<(std::ostream &stream, const SphereCollection<T> &collection) {
   stream << "{\n";
-  stream << "SphereCollection: [\n";
-  stream << "  size: " << collection.size() << ",\n";
+  stream << R"("SphereCollection": [)"
+         << "\n";
+  stream << R"({"size": )" << collection.size() << "},\n";
 
   for (uint32_t id_sphere = 0; id_sphere < collection.size(); id_sphere++) {
     stream << primitive_from_collection(collection, id_sphere);

--- a/blazert/primitives/sphere.h
+++ b/blazert/primitives/sphere.h
@@ -37,7 +37,7 @@ std::ostream &operator<<(std::ostream &stream, const Sphere<T> &sphere) {
 
   stream << "  Sphere: " << &sphere << ",\n";
   stream << "  center: [" << sphere.center[0] << "," << sphere.center[1] << "," << sphere.center[2] << "],\n";
-  stream << "  radius: " << sphere.radius<< ",\n";
+  stream << "  radius: " << sphere.radius << ",\n";
   stream << "  prim_id: " << sphere.prim_id << "\n";
 
   stream << "}\n";
@@ -120,14 +120,14 @@ private:
 };
 
 template<typename T>
-std::ostream &operator<<(std::ostream& stream, const SphereCollection<T> &collection) {
+std::ostream &operator<<(std::ostream &stream, const SphereCollection<T> &collection) {
   stream << "{\n";
   stream << "SphereCollection: [\n";
   stream << "  size: " << collection.size() << ",\n";
 
-  for(uint32_t id_sphere = 0; id_sphere < collection.size(); id_sphere++){
+  for (uint32_t id_sphere = 0; id_sphere < collection.size(); id_sphere++) {
     stream << primitive_from_collection(collection, id_sphere);
-    if(id_sphere == collection.size() - 1) {
+    if (id_sphere == collection.size() - 1) {
       stream << "]\n";
     } else {
       stream << ", \n";

--- a/blazert/primitives/sphere.h
+++ b/blazert/primitives/sphere.h
@@ -30,20 +30,6 @@ public:
   Sphere &operator=(const Sphere &rhs) = delete;
 };
 
-template<typename T>
-std::ostream &operator<<(std::ostream &stream, const Sphere<T> &sphere) {
-  /// Conveniently output a single plane as JSON.
-  stream << "{\n";
-
-  stream << "  Sphere: " << &sphere << ",\n";
-  stream << "  center: [" << sphere.center[0] << "," << sphere.center[1] << "," << sphere.center[2] << "],\n";
-  stream << "  radius: " << sphere.radius << ",\n";
-  stream << "  prim_id: " << sphere.prim_id << "\n";
-
-  stream << "}\n";
-  return stream;
-}
-
 template<typename T, template<typename A> typename Collection,
          typename = std::enable_if_t<std::is_same<typename Collection<T>::primitive_type, Sphere<T>>::value>>
 [[nodiscard]] inline Sphere<T> primitive_from_collection(const Collection<T> &collection, const unsigned int prim_idx) {
@@ -119,25 +105,6 @@ private:
   }
 };
 
-template<typename T>
-std::ostream &operator<<(std::ostream &stream, const SphereCollection<T> &collection) {
-  stream << "{\n";
-  stream << "SphereCollection: [\n";
-  stream << "  size: " << collection.size() << ",\n";
-
-  for (uint32_t id_sphere = 0; id_sphere < collection.size(); id_sphere++) {
-    stream << primitive_from_collection(collection, id_sphere);
-    if (id_sphere == collection.size() - 1) {
-      stream << "]\n";
-    } else {
-      stream << ", \n";
-    }
-  }
-
-  stream << "}\n";
-  return stream;
-}
-
 /**
    * Post BVH traversal stuff.
    * Fill `isect` if there is a hit.
@@ -212,6 +179,39 @@ inline bool intersect_primitive(SphereIntersector<T, Collection> &i, const Spher
     return true;
   }
   return false;
+}
+
+template<typename T>
+std::ostream &operator<<(std::ostream &stream, const Sphere<T> &sphere) {
+  /// Conveniently output a single plane as JSON.
+  stream << "{\n";
+
+  stream << "  Sphere: " << &sphere << ",\n";
+  stream << "  center: [" << sphere.center[0] << "," << sphere.center[1] << "," << sphere.center[2] << "],\n";
+  stream << "  radius: " << sphere.radius << ",\n";
+  stream << "  prim_id: " << sphere.prim_id << "\n";
+
+  stream << "}\n";
+  return stream;
+}
+
+template<typename T>
+std::ostream &operator<<(std::ostream &stream, const SphereCollection<T> &collection) {
+  stream << "{\n";
+  stream << "SphereCollection: [\n";
+  stream << "  size: " << collection.size() << ",\n";
+
+  for (uint32_t id_sphere = 0; id_sphere < collection.size(); id_sphere++) {
+    stream << primitive_from_collection(collection, id_sphere);
+    if (id_sphere == collection.size() - 1) {
+      stream << "]\n";
+    } else {
+      stream << ", \n";
+    }
+  }
+
+  stream << "}\n";
+  return stream;
 }
 
 }// namespace blazert

--- a/blazert/primitives/sphere.h
+++ b/blazert/primitives/sphere.h
@@ -37,7 +37,7 @@ std::ostream &operator<<(std::ostream &stream, const Sphere<T> &sphere) {
 
   stream << "  Sphere: " << &sphere << ",\n";
   stream << "  center: [" << sphere.center[0] << "," << sphere.center[1] << "," << sphere.center[2] << "],\n";
-  stream << "  radius: " << sphere.dx << ",\n";
+  stream << "  radius: " << sphere.radius<< ",\n";
   stream << "  prim_id: " << sphere.prim_id << "\n";
 
   stream << "}\n";

--- a/blazert/primitives/sphere.h
+++ b/blazert/primitives/sphere.h
@@ -30,6 +30,20 @@ public:
   Sphere &operator=(const Sphere &rhs) = delete;
 };
 
+template<typename T>
+std::ostream &operator<<(std::ostream &stream, const Sphere<T> &sphere) {
+  /// Conveniently output a single plane as JSON.
+  stream << "{\n";
+
+  stream << "  Sphere: " << &sphere << ",\n";
+  stream << "  center: [" << sphere.center[0] << "," << sphere.center[1] << "," << sphere.center[2] << "],\n";
+  stream << "  radius: " << sphere.dx << ",\n";
+  stream << "  prim_id: " << sphere.prim_id << "\n";
+
+  stream << "}\n";
+  return stream;
+}
+
 template<typename T, template<typename A> typename Collection,
          typename = std::enable_if_t<std::is_same<typename Collection<T>::primitive_type, Sphere<T>>::value>>
 [[nodiscard]] inline Sphere<T> primitive_from_collection(const Collection<T> &collection, const unsigned int prim_idx) {
@@ -104,6 +118,25 @@ private:
     return std::make_pair(std::move(min), std::move(max));
   }
 };
+
+template<typename T>
+std::ostream &operator<<(std::ostream& stream, const SphereCollection<T> &collection) {
+  stream << "{\n";
+  stream << "SphereCollection: [\n";
+  stream << "  size: " << collection.size() << ",\n";
+
+  for(uint32_t id_sphere = 0; id_sphere < collection.size(); id_sphere++){
+    stream << primitive_from_collection(collection, id_sphere);
+    if(id_sphere == collection.size() - 1) {
+      stream << "]\n";
+    } else {
+      stream << ", \n";
+    }
+  }
+
+  stream << "}\n";
+  return stream;
+}
 
 /**
    * Post BVH traversal stuff.

--- a/blazert/primitives/trimesh.h
+++ b/blazert/primitives/trimesh.h
@@ -30,6 +30,21 @@ struct Triangle {
   Triangle &operator=(const Triangle &rhs) = delete;
 };
 
+template<typename T>
+std::ostream &operator<<(std::ostream &stream, const Triangle<T> &triangle) {
+  /// Conveniently output a single plane as JSON.
+  stream << "{\n";
+
+  stream << "  Triangle: " << &triangle << ",\n";
+  stream << "  a: [" << triangle.a[0] << "," << triangle.c[1] << "," << triangle.a[2] << "],\n";
+  stream << "  b: [" << triangle.b[0] << "," << triangle.b[1] << "," << triangle.b[2] << "],\n";
+  stream << "  c: [" << triangle.c[0] << "," << triangle.c[1] << "," << triangle.c[2] << "],\n";
+  stream << "  prim_id: " << triangle.prim_id << "\n";
+
+  stream << "}\n";
+  return stream;
+}
+
 template<typename T, template<typename A> typename Collection,
          typename = std::enable_if_t<std::is_same<typename Collection<T>::primitive_type, Triangle<T>>::value>>
 [[nodiscard]] inline Triangle<T> primitive_from_collection(const Collection<T> &collection,
@@ -130,6 +145,25 @@ private:
   }
 };
 
+template<typename T>
+std::ostream &operator<<(std::ostream& stream, const TriangleMesh<T> &collection) {
+  stream << "{\n";
+  stream << "TriangleMesh: [\n";
+  stream << "  size: " << collection.size() << ",\n";
+
+  for(uint32_t id_triangle = 0; id_triangle < collection.size(); id_triangle++){
+    stream << primitive_from_collection(collection, id_triangle);
+    if(id_triangle == collection.size() - 1) {
+      stream << "]\n";
+    } else {
+      stream << ", \n";
+    }
+  }
+
+  stream << "}\n";
+  return stream;
+}
+
 template<typename T, template<typename> typename Collection>
 inline void post_traversal(const TriangleIntersector<T, Collection> &i, RayHit<T> &rayhit) noexcept {
   rayhit.hit_distance = i.hit_distance;
@@ -180,10 +214,10 @@ inline bool intersect_primitive(TriangleIntersector<T, Collection> &i, const Tri
   return false;
 }
 
-template<typename T>
-std::ostream &operator<<(std::ostream &stream, const TriangleMesh<T> &mesh) {
-  stream << "Collection size:" << mesh.size();
-  return stream;
-}
+//template<typename T>
+//std::ostream &operator<<(std::ostream &stream, const TriangleMesh<T> &mesh) {
+//  stream << "Collection size:" << mesh.size();
+//  return stream;
+//}
 }// namespace blazert
 #endif// BLAZERT_PRIMITIVES_TRIMESH_H_

--- a/blazert/primitives/trimesh.h
+++ b/blazert/primitives/trimesh.h
@@ -21,12 +21,12 @@ struct Triangle {
   const Vec3r<T> &a;
   const Vec3r<T> b;
   const Vec3r<T> c;
-  unsigned int i;
+  unsigned int prim_id;
   Triangle() = delete;
-  Triangle(const Vec3r<T> &a, const Vec3r<T> &b_, const Vec3r<T> &c_, const unsigned int i)
-      : a(a), b(c_ - a), c(a - b_), i(i) {}
+  Triangle(const Vec3r<T> &a, const Vec3r<T> &b_, const Vec3r<T> &c_, const unsigned int prim_id)
+      : a(a), b(c_ - a), c(a - b_), prim_id(prim_id) {}
   Triangle(Triangle &&rhs) noexcept
-      : a(std::move(rhs.a)), b(std::move(rhs.b)), c(std::move(rhs.c)), i(std::exchange(rhs.i, -1)) {}
+      : a(std::move(rhs.a)), b(std::move(rhs.b)), c(std::move(rhs.c)), prim_id(std::exchange(rhs.prim_id, -1)) {}
   Triangle &operator=(const Triangle &rhs) = delete;
 };
 
@@ -173,7 +173,7 @@ inline bool intersect_primitive(TriangleIntersector<T, Collection> &i, const Tri
       const auto inv_det = static_cast<T>(1.0) / abs_det;
       i.hit_distance = t * inv_det;
       i.uv = {u * inv_det, v * inv_det};
-      i.prim_id = tri.i;
+      i.prim_id = tri.prim_id;
       return true;
     }
   }

--- a/blazert/primitives/trimesh.h
+++ b/blazert/primitives/trimesh.h
@@ -30,21 +30,6 @@ struct Triangle {
   Triangle &operator=(const Triangle &rhs) = delete;
 };
 
-template<typename T>
-std::ostream &operator<<(std::ostream &stream, const Triangle<T> &triangle) {
-  /// Conveniently output a single plane as JSON.
-  stream << "{\n";
-
-  stream << "  Triangle: " << &triangle << ",\n";
-  stream << "  a: [" << triangle.a[0] << "," << triangle.c[1] << "," << triangle.a[2] << "],\n";
-  stream << "  b: [" << triangle.b[0] << "," << triangle.b[1] << "," << triangle.b[2] << "],\n";
-  stream << "  c: [" << triangle.c[0] << "," << triangle.c[1] << "," << triangle.c[2] << "],\n";
-  stream << "  prim_id: " << triangle.prim_id << "\n";
-
-  stream << "}\n";
-  return stream;
-}
-
 template<typename T, template<typename A> typename Collection,
          typename = std::enable_if_t<std::is_same<typename Collection<T>::primitive_type, Triangle<T>>::value>>
 [[nodiscard]] inline Triangle<T> primitive_from_collection(const Collection<T> &collection,
@@ -145,25 +130,6 @@ private:
   }
 };
 
-template<typename T>
-std::ostream &operator<<(std::ostream& stream, const TriangleMesh<T> &collection) {
-  stream << "{\n";
-  stream << "TriangleMesh: [\n";
-  stream << "  size: " << collection.size() << ",\n";
-
-  for(uint32_t id_triangle = 0; id_triangle < collection.size(); id_triangle++){
-    stream << primitive_from_collection(collection, id_triangle);
-    if(id_triangle == collection.size() - 1) {
-      stream << "]\n";
-    } else {
-      stream << ", \n";
-    }
-  }
-
-  stream << "}\n";
-  return stream;
-}
-
 template<typename T, template<typename> typename Collection>
 inline void post_traversal(const TriangleIntersector<T, Collection> &i, RayHit<T> &rayhit) noexcept {
   rayhit.hit_distance = i.hit_distance;
@@ -214,10 +180,39 @@ inline bool intersect_primitive(TriangleIntersector<T, Collection> &i, const Tri
   return false;
 }
 
-//template<typename T>
-//std::ostream &operator<<(std::ostream &stream, const TriangleMesh<T> &mesh) {
-//  stream << "Collection size:" << mesh.size();
-//  return stream;
-//}
+
+template<typename T>
+std::ostream &operator<<(std::ostream &stream, const Triangle<T> &triangle) {
+  /// Conveniently output a single plane as JSON.
+  stream << "{\n";
+
+  stream << "  Triangle: " << &triangle << ",\n";
+  stream << "  a: [" << triangle.a[0] << "," << triangle.c[1] << "," << triangle.a[2] << "],\n";
+  stream << "  b: [" << triangle.b[0] << "," << triangle.b[1] << "," << triangle.b[2] << "],\n";
+  stream << "  c: [" << triangle.c[0] << "," << triangle.c[1] << "," << triangle.c[2] << "],\n";
+  stream << "  prim_id: " << triangle.prim_id << "\n";
+
+  stream << "}\n";
+  return stream;
+}
+
+template<typename T>
+std::ostream &operator<<(std::ostream& stream, const TriangleMesh<T> &collection) {
+  stream << "{\n";
+  stream << "TriangleMesh: [\n";
+  stream << "  size: " << collection.size() << ",\n";
+
+  for(uint32_t id_triangle = 0; id_triangle < collection.size(); id_triangle++){
+    stream << primitive_from_collection(collection, id_triangle);
+    if(id_triangle == collection.size() - 1) {
+      stream << "]\n";
+    } else {
+      stream << ", \n";
+    }
+  }
+
+  stream << "}\n";
+  return stream;
+}
 }// namespace blazert
 #endif// BLAZERT_PRIMITIVES_TRIMESH_H_

--- a/blazert/primitives/trimesh.h
+++ b/blazert/primitives/trimesh.h
@@ -183,14 +183,14 @@ inline bool intersect_primitive(TriangleIntersector<T, Collection> &i, const Tri
 
 template<typename T>
 std::ostream &operator<<(std::ostream &stream, const Triangle<T> &triangle) {
-  /// Conveniently output a single plane as JSON.
+  /// Conveniently output a single triangle as JSON.
   stream << "{\n";
 
-  stream << "  Triangle: " << &triangle << ",\n";
-  stream << "  a: [" << triangle.a[0] << "," << triangle.c[1] << "," << triangle.a[2] << "],\n";
-  stream << "  b: [" << triangle.b[0] << "," << triangle.b[1] << "," << triangle.b[2] << "],\n";
-  stream << "  c: [" << triangle.c[0] << "," << triangle.c[1] << "," << triangle.c[2] << "],\n";
-  stream << "  prim_id: " << triangle.prim_id << "\n";
+  stream << R"(  "Triangle": )" << &triangle << ",\n";
+  stream << R"(  "a": [ )" << triangle.a[0] << ", " << triangle.c[1] << ", " << triangle.a[2] << "],\n";
+  stream << R"(  "b": [ )" << triangle.b[0] << ", " << triangle.b[1] << ", " << triangle.b[2] << "],\n";
+  stream << R"(  "c": [ )" << triangle.c[0] << ", " << triangle.c[1] << ", " << triangle.c[2] << "],\n";
+  stream << R"(  "prim_id": )" << triangle.prim_id << "\n";
 
   stream << "}\n";
   return stream;
@@ -199,8 +199,8 @@ std::ostream &operator<<(std::ostream &stream, const Triangle<T> &triangle) {
 template<typename T>
 std::ostream &operator<<(std::ostream& stream, const TriangleMesh<T> &collection) {
   stream << "{\n";
-  stream << "TriangleMesh: [\n";
-  stream << "  size: " << collection.size() << ",\n";
+  stream << R"("TriangleMesh": [)" << "\n";
+  stream << R"({"size": )" << collection.size() << "},\n";
 
   for(uint32_t id_triangle = 0; id_triangle < collection.size(); id_triangle++){
     stream << primitive_from_collection(collection, id_triangle);

--- a/blazert/ray.h
+++ b/blazert/ray.h
@@ -85,6 +85,41 @@ struct BLAZERTALIGN RayHit {
   unsigned int geom_id = static_cast<unsigned int>(-1);
 };
 
+template<typename T>
+std::ostream &operator<<(std::ostream &stream, const Ray<T> &ray) {
+  /// Conveniently output a single cylinder as JSON.
+  stream << "{\n";
+
+  stream << "  Ray: " << &ray << ",\n";
+  stream << "  origin: [" << ray.origin[0] << "," << ray.origin[1] << "," << ray.origin[2] << "],\n";
+  stream << "  direction: [" << ray.direction[0] << "," << ray.direction[1] << "," << ray.direction[2] << "],\n";
+  stream << "  direction_inv: ["<< ray.direction_inv[0] << "," << ray.direction_inv[1] << "," << ray.direction_inv[2] << "],\n";
+  stream << "  direction_sign: [" << ray.direction_sign[0] << "," << ray.direction_sign[1] << "," << ray.direction_sign[2] << "],\n";
+  stream << "  min_hit_distance: " << ray.min_hit_distance << ",\n";
+  stream << "  max_hit_distance " << ray.max_hit_distance << ",\n";
+  stream << "  cull_back_face " << (ray.cull_back_face == Ray<T>::CullBackFace::no ? "no" : "yes") << ",\n";
+  stream << "  any_hit: " << (ray.any_hit == Ray<T>::AnyHit::no ? "no" : "yes") << "\n";
+
+  stream << "}\n";
+  return stream;
+}
+
+template<typename T>
+std::ostream &operator<<(std::ostream &stream, const RayHit<T> &rayhit) {
+  /// Conveniently output a single cylinder as JSON.
+  stream << "{\n";
+
+  stream << "  Ray: " << &rayhit << ",\n";
+  stream << "  normal: [" << rayhit.normal[0] << "," << rayhit.normal[1] << "," << rayhit.normal[2] << "],\n";
+  stream << "  uv: [" << rayhit.uv[0] << "," << rayhit.uv[1] << "],\n";
+  stream << "  hit_distance: "<< rayhit.hit_distance << ",\n";
+  stream << "  prim_id: " << rayhit.prim_id << ",\n";
+  stream << "  geom_id: " << rayhit.geom_id << ",\n";
+
+  stream << "}\n";
+  return stream;
+}
+
 }// namespace blazert
 
 #endif// BLAZERT_RAY_H_

--- a/blazert/scene.h
+++ b/blazert/scene.h
@@ -117,15 +117,30 @@ public:
 
 template<typename T>
 std::ostream &operator<<(std::ostream &stream, const BlazertScene<T> &scene) {
-  /// Conveniently output a single cylinder as JSON.
+  /// Conveniently output the scene as JSON
   stream << "{\n";
 
-  stream << "  Scene: " << &scene << ",\n";
-  if (scene.triangle_collection != nullptr) stream << *scene.triangle_collection << ",\n";
-  if (scene.sphere_collection != nullptr) stream << *scene.sphere_collection << ",\n";
-  if (scene.cylinder_collection != nullptr) stream << *scene.cylinder_collection << ",\n";
-  if (scene.plane_collection != nullptr) stream << *scene.plane_collection << "\n";
+  stream << R"(  "Scene": )"
+         << (&scene)
+         << ",\n";
+  stream << R"(  "Collections": [)"
+         << "\n";
 
+  if (scene.triangle_collection != nullptr) {
+    stream << *scene.triangle_collection;
+    if (scene.has_spheres || scene.has_cylinders || scene.has_planes) stream << ",\n";
+  }
+  if (scene.sphere_collection != nullptr) {
+    stream << *scene.sphere_collection;
+    if (scene.has_cylinders || scene.has_planes) stream << ",\n";
+  }
+  if (scene.cylinder_collection != nullptr) {
+    stream << *scene.cylinder_collection;
+    if (scene.has_planes) stream << ",\n";
+  }
+  if (scene.plane_collection != nullptr) stream << *scene.plane_collection;
+
+  stream << "  ]\n";
   stream << "}\n";
   return stream;
 }

--- a/blazert/scene.h
+++ b/blazert/scene.h
@@ -115,6 +115,21 @@ public:
   };
 };
 
+template<typename T>
+std::ostream &operator<<(std::ostream &stream, const BlazertScene<T> &scene) {
+  /// Conveniently output a single cylinder as JSON.
+  stream << "{\n";
+
+  stream << "  Scene: " << &scene << ",\n";
+  if (scene.triangle_collection != nullptr) stream << *scene.triangle_collection << ",\n";
+  if (scene.sphere_collection != nullptr) stream << *scene.sphere_collection << ",\n";
+  if (scene.cylinder_collection != nullptr) stream << *scene.cylinder_collection << ",\n";
+  if (scene.plane_collection != nullptr) stream << *scene.plane_collection << "\n";
+
+  stream << "}\n";
+  return stream;
+}
+
 /**
  * @brief Runs intersection tests for a given BlazertScene and Ray.
  *


### PR DESCRIPTION
## Status
**READY**

## Description
I added `operator<<` to the following primitives and collections:
* Sphere & SphereCollection
* Cylinder & CylinderCollection
* Plane & PlaneCollection
* Triangle & TriangleMesh

The output format is JSON which is also used within the node.

## Type of Change
- [ ] bug fix 
- [x] new features
- [ ] documentation
- [ ] other 

## How to test the PR
To test the output add something like 
```cpp
std::cout << cylinders << "\n"; 
```
to the test_cylinders test cases.

## Checklist
- [x] I have run the provided clang-format
- [x] I have reviewed my code and commented if necessary
- [ ] I have added the appropriate documentation
- [ ] I have added tests to my new code
- [x] All tests pass locally
